### PR TITLE
Removed parts of the MMU functionality to use memory directly (faster…

### DIFF
--- a/GLScreen.cs
+++ b/GLScreen.cs
@@ -6,6 +6,7 @@ using Gal;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
+using Ryujinx.OsHle;
 using System;
 
 namespace Ryujinx
@@ -60,12 +61,14 @@ namespace Ryujinx
 
             unsafe void UploadBitmap()
             {
-                if (Renderer.FrameBufferPtr == 0)
+                int FbSize = Width * Height * 4;
+
+                if (Renderer.FrameBufferPtr == 0 || Renderer.FrameBufferPtr + FbSize > uint.MaxValue)
                 {
                     return;
                 }
 
-                byte* SrcPtr = (byte*)IntPtr.Add(Ns.Ram, (int)Renderer.FrameBufferPtr);
+                byte* SrcPtr = (byte*)Ns.Ram + (uint)Renderer.FrameBufferPtr;
 
                 for (int Y = 0; Y < Height; Y++)
                 {
@@ -275,7 +278,14 @@ void main(void) {
         {
             unsafe
             {
-                byte* Ptr = (byte*)IntPtr.Add(Ns.Ram, (int)Ns.Os.HidOffset);
+                long HidOffset = Ns.Os.GetVirtHidOffset();
+
+                if (HidOffset == 0 || HidOffset + Horizon.HidSize > uint.MaxValue)
+                {
+                    return;
+                }
+
+                byte* Ptr = (byte*)Ns.Ram + (uint)HidOffset;
 
                 int State = 0;
                 

--- a/Ryujinx/Cpu/Instruction/ASoftFallback.cs
+++ b/Ryujinx/Cpu/Instruction/ASoftFallback.cs
@@ -790,32 +790,6 @@ namespace ChocolArm64.Instruction
             return Res;
         }
 
-        public static AVec Shl64(AVec Vector, int Shift, int Size)
-        {
-            return Shl(Vector, Shift, Size, 8);
-        }
-
-        public static AVec Shl128(AVec Vector, int Shift, int Size)
-        {
-            return Shl(Vector, Shift, Size, 16);
-        }
-
-        private static AVec Shl(AVec Vector, int Shift, int Size, int Bytes)
-        {
-            AVec Res = new AVec();
-
-            int Elems = Bytes >> Size;
-
-            for (int Index = 0; Index < Elems; Index++)
-            {
-                ulong Value = ExtractVec(Vector, Index, Size);
-
-                Res = InsertVec(Res, Index, Size, Value << Shift);
-            }
-
-            return Res;
-        }
-
         public static AVec Sshll(AVec Vector, int Shift, int Size)
         {
             return Sshll_(Vector, Shift, Size, false);
@@ -838,32 +812,6 @@ namespace ChocolArm64.Instruction
                 long Value = ExtractSVec(Vector, Index + Part, Size);
 
                 Res = InsertSVec(Res, Index, Size + 1, Value << Shift);
-            }
-
-            return Res;
-        }
-
-        public static AVec Sshr64(AVec Vector, int Shift, int Size)
-        {
-            return Sshr(Vector, Shift, Size, 8);
-        }
-
-        public static AVec Sshr128(AVec Vector, int Shift, int Size)
-        {
-            return Sshr(Vector, Shift, Size, 16);
-        }
-
-        private static AVec Sshr(AVec Vector, int Shift, int Size, int Bytes)
-        {
-            AVec Res = new AVec();
-
-            int Elems = Bytes >> Size;
-
-            for (int Index = 0; Index < Elems; Index++)
-            {
-                long Value = ExtractSVec(Vector, Index, Size);
-
-                Res = InsertSVec(Res, Index, Size, Value >> Shift);
             }
 
             return Res;

--- a/Ryujinx/Cpu/Memory/AMemory.cs
+++ b/Ryujinx/Cpu/Memory/AMemory.cs
@@ -119,55 +119,22 @@ namespace ChocolArm64.Memory
 
         public byte ReadByte(long Position)
         {
-            return *((byte*)(RamPtr + Manager.GetPhys(Position, AMemoryPerm.Read)));
+            return *((byte*)(RamPtr + (uint)Position));
         }
 
         public ushort ReadUInt16(long Position)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Read);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 2))
-            {
-                return *((ushort*)(RamPtr + PhysPos));
-            }
-            else
-            {
-                return (ushort)(
-                    ReadByte(Position + 0) << 0 |
-                    ReadByte(Position + 1) << 8);
-            }
+            return *((ushort*)(RamPtr + (uint)Position));
         }
 
         public uint ReadUInt32(long Position)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Read);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 4))
-            {
-                return *((uint*)(RamPtr + PhysPos));
-            }
-            else
-            {
-                return (uint)(
-                    ReadUInt16(Position + 0) << 0 |
-                    ReadUInt16(Position + 2) << 16);
-            }
+            return *((uint*)(RamPtr + (uint)Position));
         }
 
         public ulong ReadUInt64(long Position)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Read);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 8))
-            {
-                return *((ulong*)(RamPtr + PhysPos));
-            }
-            else
-            {
-                return
-                    (ulong)ReadUInt32(Position + 0) << 0 |
-                    (ulong)ReadUInt32(Position + 4) << 32;
-            }
+            return *((ulong*)(RamPtr + (uint)Position));
         }
 
         public AVec ReadVector128(long Position)
@@ -186,52 +153,22 @@ namespace ChocolArm64.Memory
 
         public void WriteByte(long Position, byte Value)
         {
-            *((byte*)(RamPtr + Manager.GetPhys(Position, AMemoryPerm.Write))) = Value;
+            *((byte*)(RamPtr + (uint)Position)) = Value;
         }
 
         public void WriteUInt16(long Position, ushort Value)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Write);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 2))
-            {
-                *((ushort*)(RamPtr + PhysPos)) = Value;
-            }
-            else
-            {
-                WriteByte(Position + 0, (byte)(Value >> 0));
-                WriteByte(Position + 1, (byte)(Value >> 8));
-            }
+            *((ushort*)(RamPtr + (uint)Position)) = Value;
         }
 
         public void WriteUInt32(long Position, uint Value)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Write);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 4))
-            {
-                *((uint*)(RamPtr + PhysPos)) = Value;
-            }
-            else
-            {
-                WriteUInt16(Position + 0, (ushort)(Value >> 0));
-                WriteUInt16(Position + 2, (ushort)(Value >> 16));
-            }
+            *((uint*)(RamPtr + (uint)Position)) = Value;
         }
 
         public void WriteUInt64(long Position, ulong Value)
         {
-            long PhysPos = Manager.GetPhys(Position, AMemoryPerm.Write);
-
-            if (BitConverter.IsLittleEndian && !IsPageCrossed(Position, 8))
-            {
-                *((ulong*)(RamPtr + PhysPos)) = Value;
-            }
-            else
-            {
-                WriteUInt32(Position + 0, (uint)(Value >> 0));
-                WriteUInt32(Position + 4, (uint)(Value >> 32));
-            }
+            *((ulong*)(RamPtr + (uint)Position)) = Value;
         }
 
         public void WriteVector128(long Position, AVec Value)

--- a/Ryujinx/OsHle/Handles/HSharedMem.cs
+++ b/Ryujinx/OsHle/Handles/HSharedMem.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.OsHle.Handles
     class HSharedMem
     {
         public long PhysPos { get; private set; }
+        public long VirtPos { get; set; }
 
         public HSharedMem(long PhysPos)
         {

--- a/Ryujinx/OsHle/Handles/HTransferMem.cs
+++ b/Ryujinx/OsHle/Handles/HTransferMem.cs
@@ -9,15 +9,13 @@ namespace Ryujinx.OsHle.Handles
 
         public long Position { get; private set; }
         public long Size     { get; private set; }
-        public long PhysPos  { get; private set; }
 
-        public HTransferMem(AMemory Memory, AMemoryPerm Perm, long Position, long Size, long PhysPos)
+        public HTransferMem(AMemory Memory, AMemoryPerm Perm, long Position, long Size)
         {
             this.Memory   = Memory;
             this.Perm     = Perm;
             this.Position = Position;
             this.Size     = Size;
-            this.PhysPos  = PhysPos;
         }
     }
 }

--- a/Ryujinx/OsHle/Horizon.cs
+++ b/Ryujinx/OsHle/Horizon.cs
@@ -159,5 +159,12 @@ namespace Ryujinx.OsHle
 
             Handles.Delete(Handle);
         }
+
+        public long GetVirtHidOffset()
+        {
+            HSharedMem HidSharedMem = Handles.GetData<HSharedMem>(HidHandle);
+
+            return HidSharedMem.VirtPos;
+        }
     }
 }

--- a/Ryujinx/OsHle/Objects/ViIHOSBinderDriver.cs
+++ b/Ryujinx/OsHle/Objects/ViIHOSBinderDriver.cs
@@ -155,8 +155,7 @@ namespace Ryujinx.OsHle.Objects
 
                 HNvMap NvMap = Context.Ns.Os.Handles.GetData<HNvMap>(Handle);
 
-                Context.Ns.Gpu.Renderer.FrameBufferPtr =
-                    Context.Memory.Manager.GetPhys(NvMap.Address, AMemoryPerm.Read);
+                Context.Ns.Gpu.Renderer.FrameBufferPtr = NvMap.Address;
             }
 
             return MakeReplyParcel(Context, 0);

--- a/Ryujinx/OsHle/Svc/SvcMemory.cs
+++ b/Ryujinx/OsHle/Svc/SvcMemory.cs
@@ -77,6 +77,8 @@ namespace Ryujinx.OsHle.Svc
                 long Src = Position;
                 long Dst = HndData.PhysPos;
 
+                HndData.VirtPos = Src;
+
                 if (Memory.Manager.MapPhys(Src, Dst, Size,
                     (int)MemoryType.SharedMemory, (AMemoryPerm)Perm))
                 {
@@ -113,9 +115,7 @@ namespace Ryujinx.OsHle.Svc
 
             Memory.Manager.Reprotect(Position, Size, (AMemoryPerm)Perm);
 
-            long PhysPos = Memory.Manager.GetPhys(Position, AMemoryPerm.None);
-
-            HTransferMem HndData = new HTransferMem(Memory, MapInfo.Perm, Position, Size, PhysPos);
+            HTransferMem HndData = new HTransferMem(Memory, MapInfo.Perm, Position, Size);
 
             int Handle = Ns.Os.Handles.GenerateId(HndData);
 


### PR DESCRIPTION
…, but potentially more dangerous, WIP), also changed the Shl/Sshr immediate instructions to use IL instead of calling the method