### PR TITLE
Make HSessionObj implement IDisposable

### DIFF
--- a/Ryujinx/OsHle/Handles/HDomain.cs
+++ b/Ryujinx/OsHle/Handles/HDomain.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.OsHle.Handles
             ObjIds = new IdPool();
         }
 
-        public int GenertateObjectId(object Obj)
+        public int GenerateObjectId(object Obj)
         {
             int Id = ObjIds.GenerateId();
 

--- a/Ryujinx/OsHle/Handles/HSessionObj.cs
+++ b/Ryujinx/OsHle/Handles/HSessionObj.cs
@@ -1,12 +1,30 @@
+using System;
+
 namespace Ryujinx.OsHle.Handles
 {
-    class HSessionObj : HSession
+    class HSessionObj : HSession, IDisposable
     {
         public object Obj { get; private set; }
 
         public HSessionObj(HSession Session, object Obj) : base(Session)
         {
             this.Obj = Obj;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool Disposing)
+        {
+            if(Disposing && Obj != null)
+            {
+                if(Obj is IDisposable DisposableObj)
+                {
+                    DisposableObj.Dispose();
+                }
+            }
         }
     }
 }

--- a/Ryujinx/OsHle/Ipc/IpcHandler.cs
+++ b/Ryujinx/OsHle/Ipc/IpcHandler.cs
@@ -212,7 +212,7 @@ namespace Ryujinx.OsHle.Ipc
 
             Ns.Os.Handles.ReplaceData(HndId, Dom);
 
-            return FillResponse(Response, 0, Dom.GenertateObjectId(Dom));
+            return FillResponse(Response, 0, Dom.GenerateObjectId(Dom));
         }
 
         private static IpcMessage IpcDuplicateSessionEx(

--- a/Ryujinx/OsHle/Objects/ObjHelper.cs
+++ b/Ryujinx/OsHle/Objects/ObjHelper.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.OsHle.Objects
         {
             if (Context.Session is HDomain Dom)
             {
-                Context.Response.ResponseObjIds.Add(Dom.GenertateObjectId(Obj));
+                Context.Response.ResponseObjIds.Add(Dom.GenerateObjectId(Obj));
             }
             else
             {


### PR DESCRIPTION
This fixes homebrew that does fopen() / fclose() / fopen() on the same file - without IDisposable, the file was not being closed when svcCloseHandle() was called.

This also fixes the spelling of 'GenertateObjectId' in HDomain.