### PR TITLE
Stub set_sys functions

### DIFF
--- a/Ryujinx.Core/OsHle/Services/ServiceFactory.cs
+++ b/Ryujinx.Core/OsHle/Services/ServiceFactory.cs
@@ -46,6 +46,7 @@ namespace Ryujinx.Core.OsHle.IpcServices
                 case "pctl:a":   return new ServicePctl();
                 case "pl:u":     return new ServicePl();
                 case "set":      return new ServiceSet();
+                case "set:sys":  return new ServiceSetSys();
                 case "sfdnsres": return new ServiceSfdnsres();
                 case "sm:":      return new ServiceSm();
                 case "ssl":      return new ServiceSsl();

--- a/Ryujinx.Core/OsHle/Services/Set/ServiceSetSys.cs
+++ b/Ryujinx.Core/OsHle/Services/Set/ServiceSetSys.cs
@@ -1,0 +1,35 @@
+﻿using ChocolArm64.Memory;
+using Ryujinx.Core.OsHle.Ipc;
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Core.OsHle.IpcServices.Set
+{
+    class ServiceSetSys : IIpcService
+    {
+        private Dictionary<int, ServiceProcessRequest> m_Commands;
+
+        public IReadOnlyDictionary<int, ServiceProcessRequest> Commands => m_Commands;
+
+        public ServiceSetSys()
+        {
+            m_Commands = new Dictionary<int, ServiceProcessRequest>()
+            {
+                { 23, GetColorSetId },
+                { 24, SetColorSetId }
+            };
+        }
+
+        public static long GetColorSetId(ServiceCtx Context)
+        {
+            //Use white system theme
+            Context.ResponseData.Write(1);
+            return 0;
+        }
+
+        public static long SetColorSetId(ServiceCtx Context)
+        {            
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
This stubs set:sys functions GetColorSetId  and SetColorSetId. it allows the Homebrew Launcher 2.0+ to boot. this defaults to white theme