### PR TITLE
Improve CPU initial translation speeds

### DIFF
--- a/ChocolArm64/ATranslatedSub.cs
+++ b/ChocolArm64/ATranslatedSub.cs
@@ -31,7 +31,7 @@ namespace ChocolArm64
 
         private bool NeedsReJit;
 
-        private int MinCallCountForReJit = 5000;
+        private int MinCallCountForReJit = 250;
 
         public ATranslatedSub(DynamicMethod Method, List<ARegister> Params, HashSet<long> Callees)
         {

--- a/ChocolArm64/ATranslatedSubType.cs
+++ b/ChocolArm64/ATranslatedSubType.cs
@@ -1,11 +1,3 @@
-using ChocolArm64.Memory;
-using ChocolArm64.State;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Reflection;
-using System.Reflection.Emit;
-
 namespace ChocolArm64
 {
     enum ATranslatedSubType

--- a/ChocolArm64/ATranslatedSubType.cs
+++ b/ChocolArm64/ATranslatedSubType.cs
@@ -1,0 +1,17 @@
+using ChocolArm64.Memory;
+using ChocolArm64.State;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace ChocolArm64
+{
+    enum ATranslatedSubType
+    {
+        SubBlock,
+        SubTier0,
+        SubTier1
+    }
+}

--- a/ChocolArm64/ATranslator.cs
+++ b/ChocolArm64/ATranslator.cs
@@ -13,8 +13,6 @@ namespace ChocolArm64
 {
     public class ATranslator
     {
-        private Thread AsyncTranslation;
-
         private HashSet<long> SubBlocks;
 
         private ConcurrentDictionary<long, ATranslatedSub> CachedSubs;

--- a/ChocolArm64/ATranslator.cs
+++ b/ChocolArm64/ATranslator.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace ChocolArm64

--- a/ChocolArm64/Decoder/ADecoder.cs
+++ b/ChocolArm64/Decoder/ADecoder.cs
@@ -13,8 +13,6 @@ namespace ChocolArm64.Decoder
 
         private static ConcurrentDictionary<Type, OpActivator> OpActivators;
 
-        private const int MaxGraphLength = 40;
-
         static ADecoder()
         {
             OpActivators = new ConcurrentDictionary<Type, OpActivator>();
@@ -46,11 +44,6 @@ namespace ChocolArm64.Decoder
             {
                 if (!Visited.TryGetValue(Position, out ABlock Output))
                 {
-                    if (Visited.Count >= MaxGraphLength)
-                    {
-                        return null;
-                    }
-
                     Output = new ABlock(Position);
 
                     Blocks.Enqueue(Output);
@@ -91,8 +84,8 @@ namespace ChocolArm64.Decoder
                         }
                     }
 
-                    if ((!(LastOp is AOpCodeBImmAl) &&
-                         !(LastOp is AOpCodeBReg)) || HasCachedSub)
+                    if (!((LastOp is AOpCodeBImmAl) ||
+                          (LastOp is AOpCodeBReg)) || HasCachedSub)
                     {
                         Current.Next = Enqueue(Current.EndPosition);
                     }

--- a/ChocolArm64/Decoder/ADecoder.cs
+++ b/ChocolArm64/Decoder/ADecoder.cs
@@ -13,9 +13,23 @@ namespace ChocolArm64.Decoder
 
         private static ConcurrentDictionary<Type, OpActivator> OpActivators;
 
+        private const int MaxGraphLength = 40;
+
         static ADecoder()
         {
             OpActivators = new ConcurrentDictionary<Type, OpActivator>();
+        }
+
+        public static ABlock DecodeBasicBlock(
+            ATranslator Translator,
+            AMemory     Memory,
+            long        Start)
+        {
+            ABlock Block = new ABlock(Start);
+
+            FillBlock(Memory, Block);
+
+            return Block;
         }
 
         public static (ABlock[] Graph, ABlock Root) DecodeSubroutine(
@@ -32,6 +46,11 @@ namespace ChocolArm64.Decoder
             {
                 if (!Visited.TryGetValue(Position, out ABlock Output))
                 {
+                    if (Visited.Count >= MaxGraphLength)
+                    {
+                        return null;
+                    }
+
                     Output = new ABlock(Position);
 
                     Blocks.Enqueue(Output);

--- a/ChocolArm64/Instruction/AInstEmitException.cs
+++ b/ChocolArm64/Instruction/AInstEmitException.cs
@@ -2,6 +2,7 @@ using ChocolArm64.Decoder;
 using ChocolArm64.State;
 using ChocolArm64.Translation;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace ChocolArm64.Instruction
 {
@@ -37,6 +38,12 @@ namespace ChocolArm64.Instruction
             {
                 Context.EmitLoadState(Context.CurrBlock.Next);
             }
+            else
+            {
+                Context.EmitLdc_I8(Op.Position + 4);
+
+                Context.Emit(OpCodes.Br, Context.ExitLabel);
+            }
         }
 
         public static void Und(AILEmitterCtx Context)
@@ -59,6 +66,12 @@ namespace ChocolArm64.Instruction
             if (Context.CurrBlock.Next != null)
             {
                 Context.EmitLoadState(Context.CurrBlock.Next);
+            }
+            else
+            {
+                Context.EmitLdc_I8(Op.Position + 4);
+
+                Context.Emit(OpCodes.Br, Context.ExitLabel);
             }
         }
     }

--- a/ChocolArm64/Instruction/AInstEmitException.cs
+++ b/ChocolArm64/Instruction/AInstEmitException.cs
@@ -42,7 +42,7 @@ namespace ChocolArm64.Instruction
             {
                 Context.EmitLdc_I8(Op.Position + 4);
 
-                Context.Emit(OpCodes.Br, Context.ExitLabel);
+                Context.Emit(OpCodes.Ret);
             }
         }
 
@@ -71,7 +71,7 @@ namespace ChocolArm64.Instruction
             {
                 Context.EmitLdc_I8(Op.Position + 4);
 
-                Context.Emit(OpCodes.Br, Context.ExitLabel);
+                Context.Emit(OpCodes.Ret);
             }
         }
     }

--- a/ChocolArm64/Translation/AILEmitterCtx.cs
+++ b/ChocolArm64/Translation/AILEmitterCtx.cs
@@ -16,10 +16,6 @@ namespace ChocolArm64.Translation
 
         private Dictionary<long, AILLabel> Labels;
 
-        public AILLabel ExitLabel { get; private set; }
-
-        private bool HasExit;
-
         private int BlkIndex;
         private int OpcIndex;
 
@@ -74,8 +70,6 @@ namespace ChocolArm64.Translation
 
             Labels = new Dictionary<long, AILLabel>();
 
-            ExitLabel = new AILLabel();
-
             Emitter = new AILEmitter(Graph, Root, SubName);
 
             ILBlock = Emitter.GetILBlock(0);          
@@ -98,15 +92,6 @@ namespace ChocolArm64.Translation
             if (OpcIndex + 1 == CurrBlock.OpCodes.Count &&
                 BlkIndex + 1 == Graph.Length)
             {
-                if (!HasExit)
-                {
-                    MarkLabel(ExitLabel);
-
-                    Emit(OpCodes.Ret);
-                    
-                    HasExit = true;
-                }
-
                 return false;
             }
 

--- a/ChocolArm64/Translation/ALocalAlloc.cs
+++ b/ChocolArm64/Translation/ALocalAlloc.cs
@@ -67,9 +67,25 @@ namespace ChocolArm64.Translation
             public long VecOutputs;
         }
 
-        private const int MaxOptGraphLength = 55;
+        private const int MaxOptGraphLength = 40;
 
         public ALocalAlloc(AILBlock[] Graph, AILBlock Root)
+        {
+            IntPaths = new Dictionary<AILBlock, PathIo>();
+            VecPaths = new Dictionary<AILBlock, PathIo>();
+
+            if (Graph.Length > 1 &&
+                Graph.Length < MaxOptGraphLength)
+            {
+                InitializeOptimal(Graph, Root);
+            }
+            else
+            {
+                InitializeFast(Graph);
+            }
+        }
+
+        private void InitializeOptimal(AILBlock[] Graph, AILBlock Root)
         {
             //This will go through all possible paths on the graph,
             //and store all inputs/outputs for each block. A register
@@ -80,9 +96,6 @@ namespace ChocolArm64.Translation
             //when doing input elimination. Each block chain have a root, that's where
             //the code starts executing. They are present on the subroutine start point,
             //and on call return points too (address written to X30 by BL).
-            IntPaths = new Dictionary<AILBlock, PathIo>();
-            VecPaths = new Dictionary<AILBlock, PathIo>();
-
             HashSet<BlockIo> Visited = new HashSet<BlockIo>();
 
             Queue<BlockIo> Unvisited = new Queue<BlockIo>();
@@ -160,6 +173,38 @@ namespace ChocolArm64.Translation
                 {
                     EnqueueFromCurrent(Current.Block.Branch, false);
                 }
+            }
+        }
+
+        private void InitializeFast(AILBlock[] Graph)
+        {
+            //This is WAY faster than InitializeOptimal, but results in
+            //uneeded loads and stores, so the resulting code will be slower.
+            long IntInputs = 0, IntOutputs = 0;
+            long VecInputs = 0, VecOutputs = 0;
+
+            foreach (AILBlock Block in Graph)
+            {
+                IntInputs  |= Block.IntInputs;
+                IntOutputs |= Block.IntOutputs;
+                VecInputs  |= Block.VecInputs;
+                VecOutputs |= Block.VecOutputs;
+            }
+
+            //It's possible that not all code paths writes to those output registers,
+            //in those cases if we attempt to write an output registers that was
+            //not written, we will be just writing zero and messing up the old register value.
+            //So we just need to ensure that all outputs are loaded.
+            if (Graph.Length > 1)
+            {
+                IntInputs |= IntOutputs;
+                VecInputs |= VecOutputs;
+            }
+
+            foreach (AILBlock Block in Graph)
+            {
+                IntPaths.Add(Block, new PathIo(Block, IntInputs, IntOutputs));
+                VecPaths.Add(Block, new PathIo(Block, VecInputs, VecOutputs));
             }
         }
 

--- a/Ryujinx.Core/OsHle/Services/Set/ServiceSetSys.cs
+++ b/Ryujinx.Core/OsHle/Services/Set/ServiceSetSys.cs
@@ -1,6 +1,4 @@
-﻿using ChocolArm64.Memory;
-using Ryujinx.Core.OsHle.Ipc;
-using System;
+﻿using Ryujinx.Core.OsHle.Ipc;
 using System.Collections.Generic;
 
 namespace Ryujinx.Core.OsHle.IpcServices.Set


### PR DESCRIPTION
This enables background translation of subroutines on the CPU.
First, it trasnlates a slow version, only considering basic blocks. This runs slow but is fast to translate.
In the background, it translates a faster version of the same code. When the translation finishes, it swaps the slow version with the fast version.
This should improve startup speed.

A few things still needs to be done, like removing cold methods to avoid memory leaking. It can also be improved by not recompiling a faster version of methods that only runs once, or rarely runs.