### PR TITLE
SVC: Add GetInfo type 20 (added in 5.0.0) to the list of explicitly unimplemented types.

### DIFF
--- a/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
+++ b/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
@@ -235,7 +235,8 @@ namespace Ryujinx.Core.OsHle.Svc
 
             //Fail for info not available on older Kernel versions.
             if (InfoType == 18 ||
-                InfoType == 19)
+                InfoType == 19 ||
+                InfoType == 20)
             {
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidInfo);
 


### PR DESCRIPTION
This fixes libnx from https://github.com/switchbrew/libnx/commit/6c72bf8273d57549acfb80502476eace4cbe36d0 onwards.