### PR TITLE
[ServiceNvDrv] Add 0x4703 ([/dev/nvhost-ctrl-gpu] NvGpuIoctlZbcSetTable)

### DIFF
--- a/Ryujinx.Core/OsHle/Services/Nv/ServiceNvDrv.cs
+++ b/Ryujinx.Core/OsHle/Services/Nv/ServiceNvDrv.cs
@@ -51,6 +51,7 @@ namespace Ryujinx.Core.OsHle.Services.Nv
                 { ("/dev/nvhost-ctrl",     0x001d), NvHostIoctlCtrlEventWait          },
                 { ("/dev/nvhost-ctrl-gpu", 0x4701), NvGpuIoctlZcullGetCtxSize         },
                 { ("/dev/nvhost-ctrl-gpu", 0x4702), NvGpuIoctlZcullGetInfo            },
+                { ("/dev/nvhost-ctrl-gpu", 0x4703), NvGpuIoctlZbcSetTable             },
                 { ("/dev/nvhost-ctrl-gpu", 0x4705), NvGpuIoctlGetCharacteristics      },
                 { ("/dev/nvhost-ctrl-gpu", 0x4706), NvGpuIoctlGetTpcMasks             },
                 { ("/dev/nvhost-ctrl-gpu", 0x4714), NvGpuIoctlZbcGetActiveSlotMask    },
@@ -378,6 +379,21 @@ namespace Ryujinx.Core.OsHle.Services.Nv
             Writer.WriteInt32(0);
             Writer.WriteInt32(0);
             Writer.WriteInt32(0);
+
+            return 0;
+        }
+
+        private long NvGpuIoctlZbcSetTable(ServiceCtx Context)
+        {
+            long Position = Context.Request.GetSendBuffPtr();
+
+            MemReader Reader = new MemReader(Context.Memory, Position);
+
+            int ColorDs = Reader.ReadInt32();
+            int ColorL2 = Reader.ReadInt32();
+            int Depth   = Reader.ReadInt32();
+            int Format  = Reader.ReadInt32();
+            int Type    = Reader.ReadInt32();
 
             return 0;
         }

--- a/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
+++ b/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
@@ -297,10 +297,6 @@ namespace Ryujinx.Core.OsHle.Svc
                     ThreadState.X1 = MemoryRegions.MapRegionSize;
                     break;
 
-                case 16:
-                    ThreadState.X1 = 0;
-                    break;
-
                 default: throw new NotImplementedException($"SvcGetInfo: {InfoType} {Handle} {InfoId}");
             }
 

--- a/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
+++ b/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
@@ -297,6 +297,10 @@ namespace Ryujinx.Core.OsHle.Svc
                     ThreadState.X1 = MemoryRegions.MapRegionSize;
                     break;
 
+                case 16:
+                    ThreadState.X1 = 0;
+                    break;
+
                 default: throw new NotImplementedException($"SvcGetInfo: {InfoType} {Handle} {InfoId}");
             }
 


### PR DESCRIPTION
Implements 0x4703 (NvGpuIoctlZbcSetTable) for /dev/nvhost-ctrl-gpu into ServiceNvDrv