### PR TITLE
Show calling information in logs

### DIFF
--- a/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
+++ b/Ryujinx.Core/OsHle/Svc/SvcSystem.cs
@@ -221,7 +221,7 @@ namespace Ryujinx.Core.OsHle.Svc
 
             string Str = AMemoryHelper.ReadAsciiString(Memory, Position, Size);
 
-            Logging.Info($"SvcOutputDebugString: {Str}");
+            Logging.Info(Str);
 
             ThreadState.X0 = 0;
         }


### PR DESCRIPTION
This add the calling information to the logs, and also moves the actual printing of the log to one method. calling information is show for all log levels. ~~Only the relative path in the source code structure is shown~~ Only the calling method is shown in logs, although the log entries contains full information about the log.

Example log = https://pastebin.com/Aqthk5kM