### PR TITLE
Faster soft implementation of smulh and umulh

### DIFF
--- a/ChocolArm64/Instruction/ASoftFallback.cs
+++ b/ChocolArm64/Instruction/ASoftFallback.cs
@@ -153,12 +153,30 @@ namespace ChocolArm64.Instruction
 
         public static long SMulHi128(long LHS, long RHS)
         {
-            return (long)(BigInteger.Multiply(LHS, RHS) >> 64);
+            bool LSign = (LHS < 0);
+            bool RSign = (RHS < 0);
+
+            long Result = (long)UMulHi128((ulong)(LSign ? -LHS : LHS), (ulong)(RSign ? -RHS : RHS));
+
+            if (LSign != RSign)
+                return (-Result) - 1; //for negative results, hi 64-bits start at 0xFFF... and count back
+            return Result;
         }
 
         public static ulong UMulHi128(ulong LHS, ulong RHS)
         {
-            return (ulong)(BigInteger.Multiply(LHS, RHS) >> 64);
+            //long multiplication
+            //multiply 32 bits at a time in 64 bit, the result is what's carried over 64 bits.
+            ulong LHigh = LHS >> 32;
+            ulong LLow = LHS & 0xFFFFFFFF;
+            ulong RHigh = RHS >> 32;
+            ulong RLow = RHS & 0xFFFFFFFF;
+            ulong Z2 = LLow * RLow;
+            ulong T = LHigh * RLow + (Z2 >> 32);
+            ulong Z1 = T & 0xFFFFFFFF;
+            ulong Z0 = T >> 32;
+            Z1 += LLow * RHigh;
+            return LHigh * RHigh + Z0 + (Z1 >> 32);
         }
     }
 }

--- a/ChocolArm64/Instruction/ASoftFallback.cs
+++ b/ChocolArm64/Instruction/ASoftFallback.cs
@@ -158,7 +158,7 @@ namespace ChocolArm64.Instruction
 
             long Result = (long)UMulHi128((ulong)(LSign ? -LHS : LHS), (ulong)(RSign ? -RHS : RHS));
 
-            if (LSign != RSign)
+            if (LSign != RSign && LHS != 0 && RHS != 0)
                 return (-Result) - 1; //for negative results, hi 64-bits start at 0xFFF... and count back
             return Result;
         }

--- a/ChocolArm64/Instruction/ASoftFallback.cs
+++ b/ChocolArm64/Instruction/ASoftFallback.cs
@@ -159,7 +159,7 @@ namespace ChocolArm64.Instruction
             long Result = (long)UMulHi128((ulong)(LSign ? -LHS : LHS), (ulong)(RSign ? -RHS : RHS));
 
             if (LSign != RSign && LHS != 0 && RHS != 0)
-                return (-Result) - 1; //for negative results, hi 64-bits start at 0xFFF... and count back
+                return ~Result; //for negative results, hi 64-bits start at 0xFFF... and count back
             return Result;
         }
 


### PR DESCRIPTION
Was doing a quick profile and noticed this took up quite a bit of time. BigInteger is general purpose for variable size and does a lot of heap allocation, so just using fixed integer math is much faster here.

When multiplying 100000 sets of integers from a prebuilt array, completes about 14x faster on average than using BigInteger, and gets the same result. Also passed `Ryujinx.Tests.Cpu.CpuTestMul`.