### PR TITLE
Add UncheckedReadBytes in AMemory, for MemoryHelper when memory checks disabled

### DIFF
--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -301,6 +301,13 @@ namespace ChocolArm64.Memory
             return *((ulong*)(RamPtr + (uint)Position));
         }
 
+        public byte[] ReadByteArrayUnchecked(long Position, long Length)
+        {
+            byte[] Result = new byte[Length];
+            Marshal.Copy((IntPtr)(RamPtr + (uint)Position), Result, 0, (int)Length);
+            return Result;
+        }
+
         public Vector128<float> ReadVector8Unchecked(long Position)
         {
             if (Sse2.IsSupported)

--- a/ChocolArm64/Memory/AMemoryHelper.cs
+++ b/ChocolArm64/Memory/AMemoryHelper.cs
@@ -24,6 +24,7 @@ namespace ChocolArm64.Memory
 
         public static byte[] ReadBytes(AMemory Memory, long Position, long Size)
         {
+            if (AOptimizations.DisableMemoryChecks) return ReadBytesUnchecked(Memory, Position, Size);
             byte[] Data = new byte[Size];
 
             for (long Offs = 0; Offs < Size; Offs++)
@@ -32,6 +33,11 @@ namespace ChocolArm64.Memory
             }
 
             return Data;
+        }
+
+        public static byte[] ReadBytesUnchecked(AMemory Memory, long Position, long Size)
+        {
+            return Memory.ReadByteArrayUnchecked(Position, Size);
         }
 
         public static void WriteBytes(AMemory Memory, long Position, byte[] Data)


### PR DESCRIPTION
Before this change, services reading bytes from memory would always run the memory checks for each byte being copied, which would get rather extreme for large reads. This was particularly bad when reading GPU constant buffers from memory, but might easily crop up in other HLE functions. 

This change implements a method to quickly copy out bytes with Marshal.Copy() if memory checking is disabled. Right now this is triggered by the same config setting as enabling/disabling memory checks for the JIT compiler. 

With this, the smulh change and the texture cache merged, Odyssey's menus now run at about 10 fps guest/2fps host, making it a lot quicker to get to the menu and test things there.