### PR TITLE
Update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ If you have some homebrew that currently doesn't work within the emulator, you c
 
 **Contact**
 
-For help, support, suggestions, or if you just want to get in touch with the team; join our Discord server!
+For help, support, suggestions, or if you just want to get in touch with the team; join our Discord server!  
 https://discord.gg/VkQYXAZ
 
 **Running**
 
-To run this emulator, you need the .NET Core 2.0 (or higher) SDK.
-Run `dotnet run -c Release -- path\to\homebrew.nro` inside the Ryujinx solution folder to run homebrew apps.
+To run this emulator, you need the .NET Core 2.1 (or higher) SDK *and* the OpenAL 11 Core SDK.  
+Run `dotnet run -c Release -- path\to\homebrew.nro` inside the Ryujinx solution folder to run homebrew apps.  
 Run `dotnet run -c Release -- path\to\game_exefs_and_romfs_folder` to run official games (they need to be decrypted and extracted first!)
 
 **Compatibility**
@@ -73,5 +73,5 @@ You can check out the compatibility list within the Wiki. Only a handful of game
 
 **Latest build**
 
-These builds are compiled automatically for each commit on the master branch. They may be unstable or not work at all.
-To download the latest automatic build for Windows (64-bits), [Click Here](https://ci.appveyor.com/api/projects/gdkchan/ryujinx/artifacts/ryujinx_latest_unstable.zip?pr=false).
+These builds are compiled automatically for each commit on the master branch. They may be unstable or might not work at all.  
+The latest automatic build for Windows (64-bit) can be found on the [official website](https://ryujinx.org/#/Build).


### PR DESCRIPTION
- Markdown fixes
- Mention that OpenAL 11 Core SDK is required for **running** the emulator
- Link the `Latest Build` section to the website