### PR TITLE
Fix some thread sync issues

### DIFF
--- a/ChocolArm64/AThread.cs
+++ b/ChocolArm64/AThread.cs
@@ -46,7 +46,7 @@ namespace ChocolArm64
             {
                 Translator.ExecuteSubroutine(this, EntryPoint);
 
-                Memory.RemoveMonitor(ThreadId);
+                Memory.RemoveMonitor(ThreadState);
 
                 WorkFinished?.Invoke(this, EventArgs.Empty);
             });

--- a/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
+++ b/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
@@ -48,6 +48,16 @@ namespace ChocolArm64.Instruction
         {
             AOpCodeMemEx Op = (AOpCodeMemEx)Context.CurrOp;
 
+            if (AccType.HasFlag(AccessType.Ordered))
+            {
+                EmitBarrier(Context);
+            }
+
+            if (AccType.HasFlag(AccessType.Exclusive))
+            {
+                EmitMemoryCall(Context, nameof(AMemory.SetExclusive), Op.Rn);
+            }
+
             Context.EmitLdarg(ATranslatedSub.MemoryArgIdx);
             Context.EmitLdint(Op.Rn);
 
@@ -66,16 +76,6 @@ namespace ChocolArm64.Instruction
                 EmitReadZxCall(Context, Op.Size);
 
                 Context.EmitStintzr(Op.Rt2);
-            }
-
-            if (AccType.HasFlag(AccessType.Exclusive))
-            {
-                EmitMemoryCall(Context, nameof(AMemory.SetExclusive), Op.Rn);
-            }
-
-            if (AccType.HasFlag(AccessType.Ordered))
-            {
-                EmitBarrier(Context);
             }
         }
 
@@ -150,7 +150,7 @@ namespace ChocolArm64.Instruction
                 Context.EmitLdc_I8(0);
                 Context.EmitStintzr(Op.Rs);
 
-                Clrex(Context);
+                EmitMemoryCall(Context, nameof(AMemory.ClearExclusiveForStore));
             }
 
             Context.MarkLabel(LblEnd);
@@ -164,6 +164,11 @@ namespace ChocolArm64.Instruction
             if (Rn != -1)
             {
                 Context.EmitLdint(Rn);
+            }
+
+            if (Name == nameof(AMemory.SetExclusive))
+            {
+                Context.EmitLdc_I8(Context.CurrOp.Position);
             }
 
             Context.EmitCall(typeof(AMemory), Name);

--- a/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
+++ b/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
@@ -166,11 +166,6 @@ namespace ChocolArm64.Instruction
                 Context.EmitLdint(Rn);
             }
 
-            if (Name == nameof(AMemory.SetExclusive))
-            {
-                Context.EmitLdc_I8(Context.CurrOp.Position);
-            }
-
             Context.EmitCall(typeof(AMemory), Name);
         }
 

--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using System.Threading;
 
 namespace ChocolArm64.Memory
 {
@@ -15,32 +16,18 @@ namespace ChocolArm64.Memory
 
         public AMemoryMgr Manager { get; private set; }
 
-        private struct ExMonitor
+        private class ArmMonitor
         {
-            public long Position { get; private set; }
-
-            private bool ExState;
-
-            public ExMonitor(long Position, bool ExState)
-            {
-                this.Position = Position;
-                this.ExState  = ExState;
-            }
+            public long Position;
+            public bool ExState;
 
             public bool HasExclusiveAccess(long Position)
             {
                 return this.Position == Position && ExState;
             }
-
-            public void Reset()
-            {
-                ExState = false;
-            }
         }
 
-        private Dictionary<int, ExMonitor> Monitors;
-
-        private HashSet<long> ExAddrs;
+        private Dictionary<int, ArmMonitor> Monitors;
 
         public IntPtr Ram { get; private set; }
 
@@ -50,9 +37,7 @@ namespace ChocolArm64.Memory
         {
             Manager = new AMemoryMgr();
 
-            Monitors = new Dictionary<int, ExMonitor>();
-
-            ExAddrs = new HashSet<long>();
+            Monitors = new Dictionary<int, ArmMonitor>();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -66,85 +51,83 @@ namespace ChocolArm64.Memory
             RamPtr = (byte*)Ram;
         }
 
-        public void RemoveMonitor(int ThreadId)
+        public void RemoveMonitor(AThreadState State)
         {
             lock (Monitors)
             {
-                if (Monitors.TryGetValue(ThreadId, out ExMonitor Monitor))
-                {
-                    ExAddrs.Remove(Monitor.Position);
-                }
+                ClearExclusive(State);
 
-                Monitors.Remove(ThreadId);
+                Monitors.Remove(State.ThreadId);
             }
         }
 
-        public void SetExclusive(AThreadState ThreadState, long Position)
+        public void SetExclusive(AThreadState ThreadState, long Position, long oppos)
         {
             Position &= ~ErgMask;
 
             lock (Monitors)
             {
-                if (Monitors.TryGetValue(ThreadState.ThreadId, out ExMonitor Monitor))
+                foreach (ArmMonitor Mon in Monitors.Values)
                 {
-                    ExAddrs.Remove(Monitor.Position);
+                    if (Mon.Position == Position && Mon.ExState)
+                    {
+                        Mon.ExState = false;
+                    }
                 }
 
-                bool ExState = ExAddrs.Add(Position);
-
-                Monitor = new ExMonitor(Position, ExState);
-
-                if (!Monitors.TryAdd(ThreadState.ThreadId, Monitor))
+                if (!Monitors.TryGetValue(ThreadState.ThreadId, out ArmMonitor ThreadMon))
                 {
-                    Monitors[ThreadState.ThreadId] = Monitor;
+                    ThreadMon = new ArmMonitor();
+
+                    Monitors.Add(ThreadState.ThreadId, ThreadMon);
                 }
+
+                ThreadMon.Position = Position;
+                ThreadMon.ExState  = true;
             }
         }
 
         public bool TestExclusive(AThreadState ThreadState, long Position)
         {
+            //Note: Any call to this method also should be followed by a
+            //call to ClearExclusiveForStore if this method returns true.
             Position &= ~ErgMask;
 
-            lock (Monitors)
-            {
-                if (!Monitors.TryGetValue(ThreadState.ThreadId, out ExMonitor Monitor))
-                {
-                    return false;
-                }
+            Monitor.Enter(Monitors);
 
-                return Monitor.HasExclusiveAccess(Position);
+            if (!Monitors.TryGetValue(ThreadState.ThreadId, out ArmMonitor ThreadMon))
+            {
+                return false;
             }
+
+            bool ExState = ThreadMon.HasExclusiveAccess(Position);
+
+            if (!ExState)
+            {
+                Monitor.Exit(Monitors);
+            }
+
+            return ExState;
+        }
+
+        public void ClearExclusiveForStore(AThreadState ThreadState)
+        {
+            if (Monitors.TryGetValue(ThreadState.ThreadId, out ArmMonitor ThreadMon))
+            {
+                ThreadMon.ExState = false;
+            }
+
+            Monitor.Exit(Monitors);
         }
 
         public void ClearExclusive(AThreadState ThreadState)
         {
             lock (Monitors)
             {
-                if (Monitors.TryGetValue(ThreadState.ThreadId, out ExMonitor Monitor))
+                if (Monitors.TryGetValue(ThreadState.ThreadId, out ArmMonitor ThreadMon))
                 {
-                    Monitor.Reset();
-                    ExAddrs.Remove(Monitor.Position);
+                    ThreadMon.ExState = false;
                 }
-            }
-        }
-
-        public bool AcquireAddress(long Position)
-        {
-            Position &= ~ErgMask;
-
-            lock (Monitors)
-            {
-                return ExAddrs.Add(Position);
-            }
-        }
-
-        public void ReleaseAddress(long Position)
-        {
-            Position &= ~ErgMask;
-
-            lock (Monitors)
-            {
-                ExAddrs.Remove(Position);
             }
         }
 

--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -61,7 +61,7 @@ namespace ChocolArm64.Memory
             }
         }
 
-        public void SetExclusive(AThreadState ThreadState, long Position, long oppos)
+        public void SetExclusive(AThreadState ThreadState, long Position)
         {
             Position &= ~ErgMask;
 

--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -131,6 +131,24 @@ namespace ChocolArm64.Memory
             }
         }
 
+        public void WriteInt32ToSharedAddr(long Position, int Value)
+        {
+            long MaskedPosition = Position & ~ErgMask;
+
+            lock (Monitors)
+            {
+                foreach (ArmMonitor Mon in Monitors.Values)
+                {
+                    if (Mon.Position == MaskedPosition && Mon.ExState)
+                    {
+                        Mon.ExState = false;
+                    }
+                }
+
+                WriteInt32(Position, Value);
+            }
+        }
+
         public long GetHostPageSize()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Ryujinx.HLE/OsHle/Handles/ThreadQueue.cs
+++ b/Ryujinx.HLE/OsHle/Handles/ThreadQueue.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.OsHle.Handles
                     return;
                 }
 
-                if (Head == null || Head.Thread.ActualPriority > Wait.Thread.ActualPriority)
+                if (Head == null || Head.Thread.ActualPriority >= Wait.Thread.ActualPriority)
                 {
                     Wait.Next = Head;
 
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.OsHle.Handles
 
                 while (Curr.Next != null)
                 {
-                    if (Curr.Next.Thread.ActualPriority > Wait.Thread.ActualPriority)
+                    if (Curr.Next.Thread.ActualPriority >= Wait.Thread.ActualPriority)
                     {
                         break;
                     }

--- a/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
@@ -81,8 +81,6 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
         private void SvcSleepThread(AThreadState ThreadState)
         {
-            //Process.PrintStackTrace(ThreadState);
-
             ulong TimeoutNs = ThreadState.X0;
 
             Ns.Log.PrintDebug(LogClass.KernelSvc, "Timeout = " + TimeoutNs.ToString("x16"));

--- a/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
@@ -81,7 +81,11 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
         private void SvcSleepThread(AThreadState ThreadState)
         {
+            //Process.PrintStackTrace(ThreadState);
+
             ulong TimeoutNs = ThreadState.X0;
+
+            Ns.Log.PrintDebug(LogClass.KernelSvc, "Timeout = " + TimeoutNs.ToString("x16"));
 
             KThread CurrThread = Process.GetThread(ThreadState.Tpidr);
 
@@ -123,6 +127,10 @@ namespace Ryujinx.HLE.OsHle.Kernel
             int Handle   = (int)ThreadState.X0;
             int Priority = (int)ThreadState.X1;
 
+            Ns.Log.PrintDebug(LogClass.KernelSvc,
+                "Handle = "   + Handle  .ToString("x8") + ", " +
+                "Priority = " + Priority.ToString("x8"));
+
             KThread Thread = GetThread(ThreadState.Tpidr, Handle);
 
             if (Thread != null)
@@ -163,13 +171,6 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
         private void SvcSetThreadCoreMask(AThreadState ThreadState)
         {
-            //FIXME: This is wrong, but the "correct" way to handle
-            //this svc causes deadlocks when more often.
-            //There is probably something wrong with it still.
-            ThreadState.X0 = 0;
-
-            return;
-
             int  Handle    =  (int)ThreadState.X0;
             int  IdealCore =  (int)ThreadState.X1;
             long CoreMask  = (long)ThreadState.X2;
@@ -188,7 +189,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
                 CoreMask = 1 << IdealCore;
             }
-            else if (IdealCore != -3)
+            else
             {
                 if ((uint)IdealCore > 3)
                 {
@@ -223,11 +224,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
             //-1 is used as "don't care", so the IdealCore value is ignored.
             //-2 is used as "use NPDM default core id" (handled above).
             //-3 is used as "don't update", the old IdealCore value is kept.
-            if (IdealCore != -3)
-            {
-                Thread.IdealCore = IdealCore;
-            }
-            else if ((CoreMask & (1 << Thread.IdealCore)) == 0)
+            if (IdealCore == -3 && (CoreMask & (1 << Thread.IdealCore)) == 0)
             {
                 Ns.Log.PrintWarning(LogClass.KernelSvc, $"Invalid core mask 0x{CoreMask:x8}!");
 
@@ -236,9 +233,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
                 return;
             }
 
-            Thread.CoreMask = (int)CoreMask;
-
-            Process.Scheduler.TryToRun(Thread);
+            Process.Scheduler.ChangeCore(Thread, IdealCore, (int)CoreMask);
 
             ThreadState.X0 = 0;
         }

--- a/Ryujinx.HLE/OsHle/Kernel/SvcThreadSync.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcThreadSync.cs
@@ -314,7 +314,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
                     long MutexAddress = WaitThread.MutexAddress;
 
-                    Memory.SetExclusive(ThreadState, MutexAddress, 0);
+                    Memory.SetExclusive(ThreadState, MutexAddress);
 
                     int MutexValue = Process.Memory.ReadInt32(MutexAddress);
 
@@ -332,7 +332,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
                             break;
                         }
 
-                        Memory.SetExclusive(ThreadState, MutexAddress, 0);
+                        Memory.SetExclusive(ThreadState, MutexAddress);
 
                         MutexValue = Process.Memory.ReadInt32(MutexAddress);
                     }

--- a/Ryujinx.HLE/OsHle/Kernel/SvcThreadSync.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcThreadSync.cs
@@ -1,10 +1,6 @@
 using ChocolArm64.State;
 using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.OsHle.Handles;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
 using static Ryujinx.HLE.OsHle.ErrorCode;
 
@@ -145,8 +141,6 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
             KThread CurrThread = Process.GetThread(ThreadState.Tpidr);
 
-            MutexUnlock(CurrThread, MutexAddress);
-
             if (!CondVarWait(CurrThread, ThreadHandle, MutexAddress, CondVarAddress, Timeout))
             {
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.Timeout);
@@ -168,7 +162,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
             KThread CurrThread = Process.GetThread(ThreadState.Tpidr);
 
-            CondVarSignal(CurrThread, CondVarAddress, Count);
+            CondVarSignal(ThreadState, CurrThread, CondVarAddress, Count);
 
             ThreadState.X0 = 0;
         }
@@ -194,7 +188,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
                 CurrThread.WaitHandle   = WaitThreadHandle;
                 CurrThread.MutexAddress = MutexAddress;
 
-                InsertWaitingMutexThread(OwnerThreadHandle, WaitThread);
+                InsertWaitingMutexThreadUnsafe(OwnerThreadHandle, WaitThread);
             }
 
             Ns.Log.PrintDebug(LogClass.KernelSvc, "Entering wait state...");
@@ -208,17 +202,17 @@ namespace Ryujinx.HLE.OsHle.Kernel
             {
                 //This is the new thread that will now own the mutex.
                 //If no threads are waiting for the lock, then it should be null.
-                KThread OwnerThread = PopThread(CurrThread.MutexWaiters, x => x.MutexAddress == MutexAddress);
+                (KThread OwnerThread, int Count) = PopMutexThreadUnsafe(CurrThread, MutexAddress);
 
                 if (OwnerThread != null)
                 {
                     //Remove all waiting mutex from the old owner,
                     //and insert then on the new owner.
-                    UpdateMutexOwner(CurrThread, OwnerThread, MutexAddress);
+                    UpdateMutexOwnerUnsafe(CurrThread, OwnerThread, MutexAddress);
 
                     CurrThread.UpdatePriority();
 
-                    int HasListeners = OwnerThread.MutexWaiters.Count > 0 ? MutexHasListenersMask : 0;
+                    int HasListeners = Count >= 2 ? MutexHasListenersMask : 0;
 
                     Process.Memory.WriteInt32(MutexAddress, HasListeners | OwnerThread.WaitHandle);
 
@@ -256,6 +250,8 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
             lock (Process.ThreadSyncLock)
             {
+                MutexUnlock(WaitThread, MutexAddress);
+
                 WaitThread.CondVarSignaled = false;
 
                 Process.ThreadArbiterList.Add(WaitThread);
@@ -269,11 +265,15 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
                 lock (Process.ThreadSyncLock)
                 {
-                    WaitThread.MutexOwner?.MutexWaiters.Remove(WaitThread);
-
                     if (!WaitThread.CondVarSignaled || WaitThread.MutexOwner != null)
                     {
-                        WaitThread.MutexOwner = null;
+                        if (WaitThread.MutexOwner != null)
+                        {
+                            WaitThread.MutexOwner.MutexWaiters.Remove(WaitThread);
+                            WaitThread.MutexOwner.UpdatePriority();
+
+                            WaitThread.MutexOwner = null;
+                        }
 
                         Process.ThreadArbiterList.Remove(WaitThread);
 
@@ -291,13 +291,17 @@ namespace Ryujinx.HLE.OsHle.Kernel
             return true;
         }
 
-        private void CondVarSignal(KThread CurrThread, long CondVarAddress, int Count)
+        private void CondVarSignal(
+            AThreadState ThreadState,
+            KThread      CurrThread,
+            long         CondVarAddress,
+            int          Count)
         {
             lock (Process.ThreadSyncLock)
             {
                 while (Count == -1 || Count-- > 0)
                 {
-                    KThread WaitThread = PopThread(Process.ThreadArbiterList, x => x.CondVarAddress == CondVarAddress);
+                    KThread WaitThread = PopCondVarThreadUnsafe(CondVarAddress);
 
                     if (WaitThread == null)
                     {
@@ -308,16 +312,37 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
                     WaitThread.CondVarSignaled = true;
 
-                    AcquireMutexValue(WaitThread.MutexAddress);
+                    long MutexAddress = WaitThread.MutexAddress;
 
-                    int MutexValue = Process.Memory.ReadInt32(WaitThread.MutexAddress);
+                    Memory.SetExclusive(ThreadState, MutexAddress, 0);
+
+                    int MutexValue = Process.Memory.ReadInt32(MutexAddress);
+
+                    while (MutexValue != 0)
+                    {
+                        if (Memory.TestExclusive(ThreadState, MutexAddress))
+                        {
+                            //Wait until the lock is released.
+                            InsertWaitingMutexThreadUnsafe(MutexValue & ~MutexHasListenersMask, WaitThread);
+
+                            Process.Memory.WriteInt32(MutexAddress, MutexValue | MutexHasListenersMask);
+
+                            Memory.ClearExclusiveForStore(ThreadState);
+
+                            break;
+                        }
+
+                        Memory.SetExclusive(ThreadState, MutexAddress, 0);
+
+                        MutexValue = Process.Memory.ReadInt32(MutexAddress);
+                    }
 
                     Ns.Log.PrintDebug(LogClass.KernelSvc, "MutexValue = " + MutexValue.ToString("x8"));
 
                     if (MutexValue == 0)
                     {
                         //Give the lock to this thread.
-                        Process.Memory.WriteInt32(WaitThread.MutexAddress, WaitThread.WaitHandle);
+                        Process.Memory.WriteInt32(MutexAddress, WaitThread.WaitHandle);
 
                         WaitThread.WaitHandle     = 0;
                         WaitThread.MutexAddress   = 0;
@@ -329,46 +354,28 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
                         Process.Scheduler.WakeUp(WaitThread);
                     }
-                    else
-                    {
-                        //Wait until the lock is released.
-                        MutexValue &= ~MutexHasListenersMask;
-
-                        InsertWaitingMutexThread(MutexValue, WaitThread);
-
-                        MutexValue |= MutexHasListenersMask;
-
-                        Process.Memory.WriteInt32(WaitThread.MutexAddress, MutexValue);
-                    }
-
-                    ReleaseMutexValue(WaitThread.MutexAddress);
                 }
             }
         }
 
-        private void UpdateMutexOwner(KThread CurrThread, KThread NewOwner, long MutexAddress)
+        private void UpdateMutexOwnerUnsafe(KThread CurrThread, KThread NewOwner, long MutexAddress)
         {
             //Go through all threads waiting for the mutex,
             //and update the MutexOwner field to point to the new owner.
-            lock (Process.ThreadSyncLock)
+            for (int Index = 0; Index < CurrThread.MutexWaiters.Count; Index++)
             {
-                for (int Index = 0; Index < CurrThread.MutexWaiters.Count; Index++)
+                KThread Thread = CurrThread.MutexWaiters[Index];
+
+                if (Thread.MutexAddress == MutexAddress)
                 {
-                    KThread Thread = CurrThread.MutexWaiters[Index];
+                    CurrThread.MutexWaiters.RemoveAt(Index--);
 
-                    if (Thread.MutexAddress == MutexAddress)
-                    {
-                        CurrThread.MutexWaiters.RemoveAt(Index--);
-
-                        Thread.MutexOwner = NewOwner;
-
-                        InsertWaitingMutexThread(NewOwner, Thread);
-                    }
+                    InsertWaitingMutexThreadUnsafe(NewOwner, Thread);
                 }
             }
         }
 
-        private void InsertWaitingMutexThread(int OwnerThreadHandle, KThread WaitThread)
+        private void InsertWaitingMutexThreadUnsafe(int OwnerThreadHandle, KThread WaitThread)
         {
             KThread OwnerThread = Process.HandleTable.GetData<KThread>(OwnerThreadHandle);
 
@@ -379,47 +386,73 @@ namespace Ryujinx.HLE.OsHle.Kernel
                 return;
             }
 
-            InsertWaitingMutexThread(OwnerThread, WaitThread);
+            InsertWaitingMutexThreadUnsafe(OwnerThread, WaitThread);
         }
 
-        private void InsertWaitingMutexThread(KThread OwnerThread, KThread WaitThread)
+        private void InsertWaitingMutexThreadUnsafe(KThread OwnerThread, KThread WaitThread)
         {
-            lock (Process.ThreadSyncLock)
+            WaitThread.MutexOwner = OwnerThread;
+
+            if (!OwnerThread.MutexWaiters.Contains(WaitThread))
             {
-                WaitThread.MutexOwner = OwnerThread;
+                OwnerThread.MutexWaiters.Add(WaitThread);
 
-                if (!OwnerThread.MutexWaiters.Contains(WaitThread))
+                OwnerThread.UpdatePriority();
+            }
+        }
+
+        private (KThread, int) PopMutexThreadUnsafe(KThread OwnerThread, long MutexAddress)
+        {
+            int Count = 0;
+
+            KThread WakeThread = null;
+
+            foreach (KThread Thread in OwnerThread.MutexWaiters)
+            {
+                if (Thread.MutexAddress != MutexAddress)
                 {
-                    OwnerThread.MutexWaiters.Add(WaitThread);
+                    continue;
+                }
 
-                    OwnerThread.UpdatePriority();
+                if (WakeThread == null || Thread.ActualPriority < WakeThread.ActualPriority)
+                {
+                    WakeThread = Thread;
+                }
+
+                Count++;
+            }
+
+            if (WakeThread != null)
+            {
+                OwnerThread.MutexWaiters.Remove(WakeThread);
+            }
+
+            return (WakeThread, Count);
+        }
+
+        private KThread PopCondVarThreadUnsafe(long CondVarAddress)
+        {
+            KThread WakeThread = null;
+
+            foreach (KThread Thread in Process.ThreadArbiterList)
+            {
+                if (Thread.CondVarAddress != CondVarAddress)
+                {
+                    continue;
+                }
+
+                if (WakeThread == null || Thread.ActualPriority < WakeThread.ActualPriority)
+                {
+                    WakeThread = Thread;
                 }
             }
-        }
 
-        private KThread PopThread(List<KThread> Threads, Func<KThread, bool> Predicate)
-        {
-            KThread Thread = Threads.OrderBy(x => x.ActualPriority).FirstOrDefault(Predicate);
-
-            if (Thread != null)
+            if (WakeThread != null)
             {
-                Threads.Remove(Thread);
+                Process.ThreadArbiterList.Remove(WakeThread);
             }
 
-            return Thread;
-        }
-
-        private void AcquireMutexValue(long MutexAddress)
-        {
-            while (!Process.Memory.AcquireAddress(MutexAddress))
-            {
-                Thread.Yield();
-            }
-        }
-
-        private void ReleaseMutexValue(long MutexAddress)
-        {
-            Process.Memory.ReleaseAddress(MutexAddress);
+            return WakeThread;
         }
 
         private bool IsPointingInsideKernel(long Address)


### PR DESCRIPTION
By doing some stress test I was able to find more (yes, again...) thread synchronization issues. The below issues are fixed:
- CondVarWait mutex unlock + add to wait list was not atomic. This caused races in some games.
- CondVarSignal would sometimes write the updated mutex value to an invalid address.
- The ARM synchronization instructions (like LDAXR/STLXR) were mostly broken and races were possible even when using it correctly.
- Ordering of the arm load atomic instruction were wrong aswell (it tried to acquire the address after the load rather than before).
- TryToRun logic was broken, it would allow a thread to run on 2 different cores.

This PR should fix all the above issues.

Additionaly, during my testing, I also found a bug on libnx mutex, and also PRed a fix for that:
https://github.com/switchbrew/libnx/pull/120

Unfortunately games like Splatoon 2 still deadlocks with this, but now it is at least deterministic (it aways freezes at the same point now). SMO no longer deadlocks for me either, and I can consistently hit the start option. Games that requires SetThreadCoreMask such as VVVVVV also works with this PR. Other games with synchronization related issues seems to also have improved.

I still want to do more investigation through, like the splatoon issue or some other regressions I may have missed. Until then this is WIP. I may also put the SetThreadCoreMask hack back in the worst case to avoid regressions.

