### PR TITLE
NvGpuEngine3d: Fix uploading vertex arrays without index buffers.

### DIFF
--- a/Ryujinx.HLE/Gpu/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/NvGpuEngine3d.cs
@@ -345,7 +345,7 @@ namespace Ryujinx.HLE.Gpu
                 throw new InvalidOperationException();
             }
 
-            if (IndexSize != 0)
+            if (IndexCount != 0)
             {
                 int IbSize = IndexCount * IndexSize;
 


### PR DESCRIPTION
Since this check is preceded by `IndexSize = 1 << IndexSize;` it can't ever be 0. I think a check for IndexCount was intended here.