### PR TITLE
Fix 3 graphics related issues

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    public class OGLShader
+    class OGLShader
     {
         private class ShaderStage : IDisposable
         {

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    class OGLShader
+    public class OGLShader
     {
         private class ShaderStage : IDisposable
         {

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -80,6 +80,7 @@ namespace Ryujinx.Graphics.Gal.Shader
                 { ShaderIrInst.Frcp,   GetFrcpExpr   },
                 { ShaderIrInst.Frsq,   GetFrsqExpr   },
                 { ShaderIrInst.Fsin,   GetFsinExpr   },
+                { ShaderIrInst.Fsqrt,  GetFsqrtExpr  },
                 { ShaderIrInst.Ftos,   GetFtosExpr   },
                 { ShaderIrInst.Ftou,   GetFtouExpr   },
                 { ShaderIrInst.Ipa,    GetIpaExpr    },
@@ -715,6 +716,8 @@ namespace Ryujinx.Graphics.Gal.Shader
         private string GetFrsqExpr(ShaderIrOp Op) => GetUnaryCall(Op, "inversesqrt");
 
         private string GetFsinExpr(ShaderIrOp Op) => GetUnaryCall(Op, "sin");
+
+        private string GetFsqrtExpr(ShaderIrOp Op) => GetUnaryCall(Op, "sqrt");
 
         private string GetFtosExpr(ShaderIrOp Op)
         {

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
@@ -217,7 +217,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public static void Mufu(ShaderIrBlock Block, long OpCode)
         {
-            int SubOp = (int)(OpCode >> 20) & 7;
+            int SubOp = (int)(OpCode >> 20) & 0xf;
 
             bool AbsA = ((OpCode >> 46) & 1) != 0;
             bool NegA = ((OpCode >> 48) & 1) != 0;
@@ -226,12 +226,13 @@ namespace Ryujinx.Graphics.Gal.Shader
 
             switch (SubOp)
             {
-                case 0: Inst = ShaderIrInst.Fcos; break;
-                case 1: Inst = ShaderIrInst.Fsin; break;
-                case 2: Inst = ShaderIrInst.Fex2; break;
-                case 3: Inst = ShaderIrInst.Flg2; break;
-                case 4: Inst = ShaderIrInst.Frcp; break;
-                case 5: Inst = ShaderIrInst.Frsq; break;
+                case 0: Inst = ShaderIrInst.Fcos;  break;
+                case 1: Inst = ShaderIrInst.Fsin;  break;
+                case 2: Inst = ShaderIrInst.Fex2;  break;
+                case 3: Inst = ShaderIrInst.Flg2;  break;
+                case 4: Inst = ShaderIrInst.Frcp;  break;
+                case 5: Inst = ShaderIrInst.Frsq;  break;
+                case 8: Inst = ShaderIrInst.Fsqrt; break;
 
                 default: throw new NotImplementedException(SubOp.ToString());
             }

--- a/Ryujinx.Graphics/Gal/Shader/ShaderIrInst.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderIrInst.cs
@@ -43,6 +43,7 @@ namespace Ryujinx.Graphics.Gal.Shader
         Frcp,
         Frsq,
         Fsin,
+        Fsqrt,
         Ftos,
         Ftou,
         Ipa,

--- a/Ryujinx.HLE/Gpu/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/NvGpuEngine3d.cs
@@ -248,6 +248,15 @@ namespace Ryujinx.HLE.Gpu
 
             int TextureHandle = Vmm.ReadInt32(Position);
 
+            if (TextureHandle == 0)
+            {
+                //TODO: Is this correct?
+                //Some games like puyo puyo will have 0 handles.
+                //It may be just normal behaviour or a bug caused by sync issues.
+                //The game does initialize the value properly after through.
+                return;
+            }
+
             int TicIndex = (TextureHandle >>  0) & 0xfffff;
             int TscIndex = (TextureHandle >> 20) & 0xfff;
 
@@ -314,7 +323,7 @@ namespace Ryujinx.HLE.Gpu
                     continue;
                 }
 
-                for (int Cbuf = 0; Cbuf < ConstBuffers.Length; Cbuf++)
+                for (int Cbuf = 0; Cbuf < ConstBuffers[Index].Length; Cbuf++)
                 {
                     ConstBuffer Cb = ConstBuffers[Index][Cbuf];
 

--- a/Ryujinx.HLE/Gpu/TextureFactory.cs
+++ b/Ryujinx.HLE/Gpu/TextureFactory.cs
@@ -41,6 +41,17 @@ namespace Ryujinx.HLE.Gpu
 
             TextureSwizzle Swizzle = (TextureSwizzle)((Tic[2] >> 21) & 7);
 
+            if (Swizzle == TextureSwizzle.BlockLinear ||
+                Swizzle == TextureSwizzle.BlockLinearColorKey)
+            {
+                TextureAddress &= ~0x1ffL;
+            }
+            else if (Swizzle == TextureSwizzle.Pitch ||
+                     Swizzle == TextureSwizzle.PitchColorKey)
+            {
+                TextureAddress &= ~0x1fL;
+            }
+
             int Pitch = (Tic[3] & 0xffff) << 5;
 
             int BlockHeightLog2 = (Tic[3] >> 3) & 7;

--- a/Ryujinx.HLE/Gpu/TextureHelper.cs
+++ b/Ryujinx.HLE/Gpu/TextureHelper.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.HLE.Gpu
         {
             switch (Texture.Swizzle)
             {
+                case TextureSwizzle._1dBuffer:
                 case TextureSwizzle.Pitch:
                 case TextureSwizzle.PitchColorKey:
                      return new LinearSwizzle(Texture.Pitch, Bpp);

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvMap/NvMapHandle.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvMap/NvMapHandle.cs
@@ -24,14 +24,14 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvMap
             this.Size = Size;
         }
 
-        public long IncrementRefCount()
+        public void IncrementRefCount()
         {
-            return Interlocked.Increment(ref Dupes);
+            Interlocked.Increment(ref Dupes);
         }
 
         public long DecrementRefCount()
         {
-            return Interlocked.Decrement(ref Dupes);
+            return Interlocked.Decrement(ref Dupes) + 1;
         }
     }
 }

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvMap/NvMapIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvMap/NvMapIoctl.cs
@@ -163,9 +163,9 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvMap
                 return NvResult.InvalidInput;
             }
 
-            long RefCount = Map.DecrementRefCount();
+            long OldRefCount = Map.DecrementRefCount();
 
-            if (RefCount <= 0)
+            if (OldRefCount <= 1)
             {
                 DeleteNvMap(Context, Args.Handle);
 
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvMap
                 Args.Flags = FlagNotFreedYet;
             }
 
-            Args.RefCount = RefCount;
+            Args.RefCount = OldRefCount;
             Args.Size     = Map.Size;
 
             AMemoryHelper.Write(Context.Memory, OutputPosition, Args);


### PR DESCRIPTION
This fixes 3 issues found while testing puyo puyo tetris (probably affects other games aswell):

- Due to the wrong array length being used on a bidimensional array, only the first 6 constant buffers where actually set on the shader uniforms.
- SubOp 8 on the MUFU shader instruction is valid (it is the square root instruction), but the value was being masked and only 3 bits (0-7) were being used, so it was emiting a cossine operation for the square root aswell.
- NvMap Free should return the old reference count value, before the decrement, however it was returning the new value. This caused cleanup code to not function properly and resulted in wrong texture addresses being used. It expects the value to be != 0 to free the user resources.

This game was also using a 0 value for the texture handle. However it updates with the correct value shortly after, so a check was added to ignore the invalid handle values. It's unknown what this does on real hardware, or if this happens on real hardware or its an emulator bug.