### PR TITLE
Implementation of UBOs instead of uniform constant arrays

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
@@ -1,0 +1,113 @@
+using System;
+using OpenTK.Graphics.OpenGL;
+
+namespace Ryujinx.Graphics.Gal.OpenGL
+{
+    abstract class OGLStreamBuffer : IDisposable
+    {
+        public int Handle { get; protected set; }
+
+        public int Size { get; protected set; }
+
+        protected BufferTarget Target { get; private set; }
+
+        private bool Mapped = false;
+
+        public OGLStreamBuffer(BufferTarget Target, int MaxSize)
+        {
+            Handle = 0;
+            Mapped = false;
+
+            this.Target = Target;
+            this.Size = MaxSize;
+        }
+
+        public static OGLStreamBuffer Create(BufferTarget Target, int MaxSize)
+        {
+            //TODO: Query here for ARB_buffer_storage and use when available
+            return new SubDataBuffer(Target, MaxSize);
+        }
+
+        public byte[] Map(int Size)
+        {
+            if (Handle == 0 || Mapped || Size > this.Size)
+            {
+                throw new InvalidOperationException();
+            }
+
+            byte[] Memory = InternMap(Size);
+
+            Mapped = true;
+
+            return Memory;
+        }
+
+        public void Unmap(int UsedSize)
+        {
+            if (Handle == 0 || !Mapped)
+            {
+                throw new InvalidOperationException();
+            }
+
+            InternUnmap(UsedSize);
+
+            Mapped = false;
+        }
+
+        protected abstract byte[] InternMap(int Size);
+
+        protected abstract void InternUnmap(int UsedSize);
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool Disposing)
+        {
+            if (Disposing && Handle != 0)
+            {
+                GL.DeleteBuffer(Handle);
+
+                Handle = 0;
+            }
+        }
+    }
+
+    class SubDataBuffer : OGLStreamBuffer
+    {
+        private byte[] Memory;
+
+        public SubDataBuffer(BufferTarget Target, int MaxSize)
+            : base(Target, MaxSize)
+        {
+            Memory = new byte[MaxSize];
+
+            GL.CreateBuffers(1, out int Handle);
+
+            GL.BindBuffer(Target, Handle);
+
+            GL.BufferData(Target, Size, IntPtr.Zero, BufferUsageHint.StreamDraw);
+
+            this.Handle = Handle;
+        }
+
+        protected override byte[] InternMap(int Size)
+        {
+            return Memory;
+        }
+
+        protected override void InternUnmap(int UsedSize)
+        {
+            GL.BindBuffer(Target, Handle);
+            
+            unsafe
+            {
+                fixed (byte* MemoryPtr = Memory)
+                {
+                    GL.BufferSubData(Target, IntPtr.Zero, UsedSize, (IntPtr)MemoryPtr);
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -145,7 +145,9 @@ namespace Ryujinx.Graphics.Gal.Shader
 
             foreach (ShaderDeclInfo DeclInfo in Decl.Uniforms.Values.OrderBy(DeclKeySelector))
             {
-                SB.AppendLine($"uniform {GetDecl(DeclInfo)}[{DeclInfo.Index + 1}];");
+                SB.AppendLine($"layout (std140) uniform {DeclInfo.Name} {{");
+                SB.AppendLine($"{IdentationStr}vec4 {DeclInfo.Name}_data[{DeclInfo.Index / 4 + 1}];");
+                SB.AppendLine($"}};");
             }
 
             if (Decl.Uniforms.Count > 0)
@@ -530,15 +532,15 @@ namespace Ryujinx.Graphics.Gal.Shader
 
             if (Cbuf.Offs != null)
             {
-                //Note: We assume that the register value is always a multiple of 4.
-                //This may not be aways the case.
-                string Offset = "(floatBitsToInt(" + GetSrcExpr(Cbuf.Offs) + ") >> 2)";
+                string Offset = "floatBitsToInt(" + GetSrcExpr(Cbuf.Offs) + ")";
 
-                return DeclInfo.Name + "[" + Cbuf.Pos + " + " + Offset + "]";
+                string Index = "(" + Cbuf.Pos * 4 + " + " + Offset + ")";
+
+                return $"{DeclInfo.Name}_data[{Index} / 16][({Index} / 4) % 4]";
             }
             else
             {
-                return DeclInfo.Name + "[" + Cbuf.Pos + "]";
+                return $"{DeclInfo.Name}_data[{Cbuf.Pos / 4}][{Cbuf.Pos % 4}]";
             }
         }
 


### PR DESCRIPTION
Like title says, it uses UBOs instead of constant uniforms. It's implemented for Maxwell's constant buffers, not for other uniforms (flip, samplers).

It uses 16 KiB for every used constant buffers (that's an OpenGL standard limit), that's 4096 floats per buffer, hopefully games use less than that. It also uses vec4s instead of floats.