### PR TITLE
Add support for Vertex Program A and other small shader improvements

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalShader.cs
+++ b/Ryujinx.Graphics/Gal/IGalShader.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.Graphics.Gal
     {
         void Create(IGalMemory Memory, long Key, GalShaderType Type);
 
+        void Create(IGalMemory Memory, long VpAPos, long Key, GalShaderType Type);
+
         IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key);
 
         void SetConstBuffer(long Key, int Cbuf, byte[] Data);

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -97,25 +97,43 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public void Create(IGalMemory Memory, long Key, GalShaderType Type)
         {
-            Stages.GetOrAdd(Key, (Stage) => ShaderStageFactory(Memory, Key, Type));
+            Stages.GetOrAdd(Key, (Stage) => ShaderStageFactory(Memory, Key, 0, false, Type));
         }
 
-        private ShaderStage ShaderStageFactory(IGalMemory Memory, long Position, GalShaderType Type)
+        public void Create(IGalMemory Memory, long VpAPos, long Key, GalShaderType Type)
         {
-            GlslProgram Program = GetGlslProgram(Memory, Position, Type);
+            Stages.GetOrAdd(Key, (Stage) => ShaderStageFactory(Memory, VpAPos, Key, true, Type));
+        }
+
+        private ShaderStage ShaderStageFactory(
+            IGalMemory    Memory,
+            long          Position,
+            long          PositionB,
+            bool          IsDualVp,
+            GalShaderType Type)
+        {
+            GlslProgram Program;
+
+            GlslDecompiler Decompiler = new GlslDecompiler();
+
+            if (IsDualVp)
+            {
+                Program = Decompiler.Decompile(
+                    Memory,
+                    Position  + 0x50,
+                    PositionB + 0x50,
+                    Type);
+            }
+            else
+            {
+                Program = Decompiler.Decompile(Memory, Position + 0x50, Type);
+            }
 
             return new ShaderStage(
                 Type,
                 Program.Code,
                 Program.Textures,
                 Program.Uniforms);
-        }
-
-        private GlslProgram GetGlslProgram(IGalMemory Memory, long Position, GalShaderType Type)
-        {
-            GlslDecompiler Decompiler = new GlslDecompiler();
-
-            return Decompiler.Decompile(Memory, Position + 0x50, Type);
         }
 
         public IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key)
@@ -283,7 +301,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                 return FreeBinding;
             }
-            
+
             BindUniformBuffersIfNotNull(Current.Vertex);
             BindUniformBuffersIfNotNull(Current.TessControl);
             BindUniformBuffersIfNotNull(Current.TessEvaluation);

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
@@ -28,12 +28,13 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public const string FlipUniformName = "flip";
 
+        public const string StageProgramBName = "program_b";
+
         private string[] StagePrefixes = new string[] { "vp", "tcp", "tep", "gp", "fp" };
 
         private string StagePrefix;
 
         private Dictionary<int, ShaderDeclInfo> m_Textures;
-
         private Dictionary<int, ShaderDeclInfo> m_Uniforms;
 
         private Dictionary<int, ShaderDeclInfo> m_InAttributes;
@@ -43,7 +44,6 @@ namespace Ryujinx.Graphics.Gal.Shader
         private Dictionary<int, ShaderDeclInfo> m_Preds;
 
         public IReadOnlyDictionary<int, ShaderDeclInfo> Textures => m_Textures;
-
         public IReadOnlyDictionary<int, ShaderDeclInfo> Uniforms => m_Uniforms;
 
         public IReadOnlyDictionary<int, ShaderDeclInfo> InAttributes  => m_InAttributes;
@@ -54,7 +54,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public GalShaderType ShaderType { get; private set; }
 
-        public GlslDecl(ShaderIrBlock[] Blocks, GalShaderType ShaderType)
+        public GlslDecl(GalShaderType ShaderType)
         {
             this.ShaderType = ShaderType;
 
@@ -80,7 +80,10 @@ namespace Ryujinx.Graphics.Gal.Shader
             {
                 m_OutAttributes.Add(7, new ShaderDeclInfo("gl_Position", -1, 0, 4));
             }
+        }
 
+        public void Add(ShaderIrBlock[] Blocks)
+        {
             foreach (ShaderIrBlock Block in Blocks)
             {
                 foreach (ShaderIrNode Node in Block.GetNodes())
@@ -89,7 +92,6 @@ namespace Ryujinx.Graphics.Gal.Shader
                 }
             }
         }
-
         private void Traverse(ShaderIrNode Parent, ShaderIrNode Node)
         {
             switch (Node)

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -336,7 +336,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
             if (Decl.ShaderType == GalShaderType.Vertex)
             {
-                SB.AppendLine(IdentationStr + "gl_Position.xy *= flip;");
+                SB.AppendLine(IdentationStr + "gl_Position.xy *= " + GlslDecl.FlipUniformName + ";");
 
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + " = gl_Position;");
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + ".w = 1;");

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -184,6 +184,8 @@ namespace Ryujinx.Graphics.Gal.Shader
                 SB.AppendLine("uniform vec2 " + GlslDecl.FlipUniformName + ";");
             }
 
+            SB.AppendLine();
+
             foreach (ShaderDeclInfo DeclInfo in Decl.Uniforms.Values.OrderBy(DeclKeySelector))
             {
                 SB.AppendLine($"layout (std140) uniform {DeclInfo.Name} {{");

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -334,6 +334,14 @@ namespace Ryujinx.Graphics.Gal.Shader
                 SB.AppendLine(IdentationStr + DeclInfo.Name + " = " + Attr.Name + Swizzle + ";");
             }
 
+            if (Decl.ShaderType == GalShaderType.Vertex)
+            {
+                SB.AppendLine(IdentationStr + "gl_Position.xy *= flip;");
+
+                SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + " = gl_Position;");
+                SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + ".w = 1;");
+            }
+
             SB.AppendLine("}");
         }
 
@@ -475,18 +483,6 @@ namespace Ryujinx.Graphics.Gal.Shader
                         }
 
                         continue;
-                    }
-                    else if (Op.Inst == ShaderIrInst.Exit)
-                    {
-                        //Do everything that needs to be done before
-                        //the shader ends here.
-                        if (Decl.ShaderType == GalShaderType.Vertex)
-                        {
-                            SB.AppendLine(Identation + "gl_Position.xy *= flip;");
-
-                            SB.AppendLine(Identation + GlslDecl.PositionOutAttrName + " = gl_Position;");
-                            SB.AppendLine(Identation + GlslDecl.PositionOutAttrName + ".w = 1;");
-                        }
                     }
 
                     SB.AppendLine(Identation + GetSrcExpr(Op, true) + ";");

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -113,10 +113,10 @@ namespace Ryujinx.Graphics.Gal.Shader
             Blocks  = ShaderDecoder.Decode(Memory, VpAPosition);
             BlocksB = ShaderDecoder.Decode(Memory, VpBPosition);
 
-            Decl = new GlslDecl(ShaderType);
+            GlslDecl DeclVpA = new GlslDecl(Blocks,  ShaderType);
+            GlslDecl DeclVpB = new GlslDecl(BlocksB, ShaderType);
 
-            Decl.Add(Blocks);
-            Decl.Add(BlocksB);
+            Decl = GlslDecl.Merge(DeclVpA, DeclVpB);
 
             return Decompile();
         }
@@ -126,9 +126,7 @@ namespace Ryujinx.Graphics.Gal.Shader
             Blocks  = ShaderDecoder.Decode(Memory, Position);
             BlocksB = null;
 
-            Decl = new GlslDecl(ShaderType);
-
-            Decl.Add(Blocks);
+            Decl = new GlslDecl(Blocks, ShaderType);
 
             return Decompile();
         }

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
@@ -31,6 +31,24 @@ namespace Ryujinx.Graphics.Gal.Shader
             EmitAluBinaryF(Block, OpCode, ShaderOper.Immf, ShaderIrInst.Fadd);
         }
 
+        public static void Fadd_I32(ShaderIrBlock Block, long OpCode)
+        {
+            ShaderIrNode OperA = GetOperGpr8     (OpCode);
+            ShaderIrNode OperB = GetOperImmf32_20(OpCode);
+
+            bool NegB = ((OpCode >> 53) & 1) != 0;
+            bool AbsA = ((OpCode >> 54) & 1) != 0;
+            bool NegA = ((OpCode >> 56) & 1) != 0;
+            bool AbsB = ((OpCode >> 57) & 1) != 0;
+
+            OperA = GetAluFabsFneg(OperA, AbsA, NegA);
+            OperB = GetAluFabsFneg(OperB, AbsB, NegB);
+
+            ShaderIrOp Op = new ShaderIrOp(ShaderIrInst.Fadd, OperA, OperB);
+
+            Block.AddNode(GetPredNode(new ShaderIrAsg(GetOperGpr0(OpCode), Op), OpCode));
+        }
+
         public static void Fadd_R(ShaderIrBlock Block, long OpCode)
         {
             EmitAluBinaryF(Block, OpCode, ShaderOper.RR, ShaderIrInst.Fadd);

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeFlow.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeFlow.cs
@@ -24,7 +24,14 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public static void Exit(ShaderIrBlock Block, long OpCode)
         {
-            Block.AddNode(GetPredNode(new ShaderIrOp(ShaderIrInst.Exit), OpCode));
+            int CCode = (int)OpCode & 0x1f;
+
+            //TODO: Figure out what the other condition codes mean...
+            if (CCode == 0xf)
+            {
+                Block.AddNode(GetPredNode(new ShaderIrOp(ShaderIrInst.Exit), OpCode));
+            }
+
         }
 
         public static void Kil(ShaderIrBlock Block, long OpCode)

--- a/Ryujinx.Graphics/Gal/Shader/ShaderOpCodeTable.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderOpCodeTable.cs
@@ -39,14 +39,15 @@ namespace Ryujinx.Graphics.Gal.Shader
             Set("0101110010110x", ShaderDecode.F2i_R);
             Set("0100110001011x", ShaderDecode.Fadd_C);
             Set("0011100x01011x", ShaderDecode.Fadd_I);
+            Set("000010xxxxxxxx", ShaderDecode.Fadd_I32);
             Set("0101110001011x", ShaderDecode.Fadd_R);
             Set("010010011xxxxx", ShaderDecode.Ffma_CR);
-            Set("001100101xxxxx", ShaderDecode.Ffma_I);
+            Set("0011001x1xxxxx", ShaderDecode.Ffma_I);
             Set("010100011xxxxx", ShaderDecode.Ffma_RC);
             Set("010110011xxxxx", ShaderDecode.Ffma_RR);
-            Set("00011110xxxxxx", ShaderDecode.Fmul_I32);
             Set("0100110001101x", ShaderDecode.Fmul_C);
             Set("0011100x01101x", ShaderDecode.Fmul_I);
+            Set("00011110xxxxxx", ShaderDecode.Fmul_I32);
             Set("0101110001101x", ShaderDecode.Fmul_R);
             Set("0100110001100x", ShaderDecode.Fmnmx_C);
             Set("0011100x01100x", ShaderDecode.Fmnmx_I);

--- a/Ryujinx.Graphics/Gal/ShaderDeclInfo.cs
+++ b/Ryujinx.Graphics/Gal/ShaderDeclInfo.cs
@@ -23,13 +23,5 @@ namespace Ryujinx.Graphics.Gal
                 Size = NewSize;
             }
         }
-
-        internal void SetCbufOffs(int Offs)
-        {
-            if (Index < Offs)
-            {
-                Index = Offs;
-            }
-        }
     }
 }

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -125,7 +125,33 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             long BasePosition = MakeInt64From2xInt32(NvGpuEngine3dReg.ShaderAddress);
 
-            for (int Index = 0; Index < 6; Index++)
+            int Index = 1;
+
+            int VpAControl = ReadRegister(NvGpuEngine3dReg.ShaderNControl);
+
+            bool VpAEnable = (VpAControl & 1) != 0;
+
+            if (VpAEnable)
+            {
+                //Note: The maxwell supports 2 vertex programs, usually
+                //only VP B is used, but in some cases VP A is also used.
+                //In this case, it seems to function as an extra vertex
+                //shader stage.
+                //The graphics abstraction layer has a special overload for this
+                //case, which should merge the two shaders into one vertex shader.
+                int VpAOffset = ReadRegister(NvGpuEngine3dReg.ShaderNOffset);
+                int VpBOffset = ReadRegister(NvGpuEngine3dReg.ShaderNOffset + 0x10);
+
+                long VpAPos = BasePosition + (uint)VpAOffset;
+                long VpBPos = BasePosition + (uint)VpBOffset;
+
+                Gpu.Renderer.Shader.Create(Vmm, VpAPos, VpBPos, GalShaderType.Vertex);
+                Gpu.Renderer.Shader.Bind(VpBPos);
+
+                Index = 2;
+            }
+
+            for (; Index < 6; Index++)
             {
                 int Control = ReadRegister(NvGpuEngine3dReg.ShaderNControl + Index * 0x10);
                 int Offset  = ReadRegister(NvGpuEngine3dReg.ShaderNOffset  + Index * 0x10);


### PR DESCRIPTION
This change:

- Adds partial support for vertex program A shaders.
- Adds the FADD_I32 shader instruction.
- Fixes the FFMA_I encoding (it had a bit that was fixed to 0).

Vertex program A seems to be an extra shader stage on maxwell that is not used often. It seems that the gpu actually supports 2 vertex shaders, games like Farming Simulator Switch Edition needs it.

I added support on the GlslDecompiler (as adding support for it on the decoder would be way more complicated I believe).  It basically has an extra overload now that allows passing 2 shader addresses, in this case it translates the Vertex Program A as "main" and then calls Vertex Program B on the exit points. Its still necessary to handle cases like a value being passed on an attribute in VPA and then being read in VPB, then being passed again in VPB and similar cases. The easiest way I could think to do that is creating temps to store the output/input attributes shared between VPA/VPB and then replacing all uses on the IR with those temps, which is still a bit complicated to do.

I'm not very happy with this code so suggestions are aways welcome.

FYI @ReinUsesLisp as I think this may impact your work on SPIR-V aswell.