### PR TITLE
Add support for vertex base on indexed draws (fixes #185)

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -28,6 +28,6 @@ namespace Ryujinx.Graphics.Gal
 
         void DrawArrays(int First, int PrimCount, GalPrimitiveType PrimType);
 
-        void DrawElements(long IboKey, int First, GalPrimitiveType PrimType);
+        void DrawElements(long IboKey, int First, int VertexBase, GalPrimitiveType PrimType);
     }
 }

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -487,7 +487,9 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             if (IndexCount != 0)
             {
-                Gpu.Renderer.Rasterizer.DrawElements(IndexPosition, IndexFirst, PrimType);
+                int VertexBase = ReadRegister(NvGpuEngine3dReg.VertexArrayElemBase);
+
+                Gpu.Renderer.Rasterizer.DrawElements(IndexPosition, IndexFirst, VertexBase, PrimType);
             }
             else
             {


### PR DESCRIPTION
This adds support for passing the base vertex element base when a draw is made with a index buffer. The only game that is know to use that so far is Stardew Valley. This fixes most observed graphical issues on this game but the screen is still upside down.