### PR TITLE
Explicit GLSL "position" attribute location

### DIFF
--- a/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public const int GlPositionVec4Index = 7;
 
+        public const int PositionOutAttrLocation = 15;
+
         private const int AttrStartIndex = 8;
         private const int TexStartIndex = 8;
 

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -208,7 +208,7 @@ namespace Ryujinx.Graphics.Gal.Shader
         {
             if (Decl.ShaderType == GalShaderType.Fragment)
             {
-                SB.AppendLine("in vec4 " + GlslDecl.PositionOutAttrName + ";");
+                SB.AppendLine("layout (location = " + GlslDecl.PositionOutAttrLocation + ") in vec4 " + GlslDecl.PositionOutAttrName + ";");
             }
 
             PrintDeclAttributes(Decl.InAttributes.Values, "in");
@@ -218,7 +218,7 @@ namespace Ryujinx.Graphics.Gal.Shader
         {
             if (Decl.ShaderType == GalShaderType.Vertex)
             {
-                SB.AppendLine("out vec4 " + GlslDecl.PositionOutAttrName + ";");
+                SB.AppendLine("layout (location = " + GlslDecl.PositionOutAttrLocation + ") out vec4 " + GlslDecl.PositionOutAttrName + ";");
             }
 
             PrintDeclAttributes(Decl.OutAttributes.Values, "out");


### PR DESCRIPTION
A buggy OpenGL driver fails to link with implicit host-required "position" attribute location. This PR forces the attribute to be in location 15.

It may be an argument that if a shader uses 16 attributes they would overlap. The problem is that the driver wouldn't find a position for it either.

I found this issue in Axiom Verge on NVidia (propietary).