### PR TITLE
Add SMAXP, SMINP, UMAX, UMAXP, UMIN and UMINP cpu instructions

### DIFF
--- a/ChocolArm64/AOpCodeTable.cs
+++ b/ChocolArm64/AOpCodeTable.cs
@@ -362,7 +362,9 @@ namespace ChocolArm64
             SetA64("0x00111100>>>xxx100001xxxxxxxxxx", AInstEmit.Shrn_V,        typeof(AOpCodeSimdShImm));
             SetA64("0x1011110>>>>xxx010101xxxxxxxxxx", AInstEmit.Sli_V,         typeof(AOpCodeSimdShImm));
             SetA64("0x001110<<1xxxxx011001xxxxxxxxxx", AInstEmit.Smax_V,        typeof(AOpCodeSimdReg));
+            SetA64("0x001110<<1xxxxx101001xxxxxxxxxx", AInstEmit.Smaxp_V,       typeof(AOpCodeSimdReg));
             SetA64("0x001110<<1xxxxx011011xxxxxxxxxx", AInstEmit.Smin_V,        typeof(AOpCodeSimdReg));
+            SetA64("0x001110<<1xxxxx101011xxxxxxxxxx", AInstEmit.Sminp_V,       typeof(AOpCodeSimdReg));
             SetA64("0x001110<<1xxxxx100000xxxxxxxxxx", AInstEmit.Smlal_V,       typeof(AOpCodeSimdReg));
             SetA64("0x001110<<1xxxxx110000xxxxxxxxxx", AInstEmit.Smull_V,       typeof(AOpCodeSimdReg));
             SetA64("01011110<<100001010010xxxxxxxxxx", AInstEmit.Sqxtn_S,       typeof(AOpCodeSimd));
@@ -400,6 +402,10 @@ namespace ChocolArm64
             SetA64("011111100x100001110110xxxxxxxxxx", AInstEmit.Ucvtf_S,       typeof(AOpCodeSimd));
             SetA64("0x1011100x100001110110xxxxxxxxxx", AInstEmit.Ucvtf_V,       typeof(AOpCodeSimd));
             SetA64("0x101110<<1xxxxx000001xxxxxxxxxx", AInstEmit.Uhadd_V,       typeof(AOpCodeSimdReg));
+            SetA64("0x101110<<1xxxxx011001xxxxxxxxxx", AInstEmit.Umax_V,        typeof(AOpCodeSimdReg));
+            SetA64("0x101110<<1xxxxx101001xxxxxxxxxx", AInstEmit.Umaxp_V,       typeof(AOpCodeSimdReg));
+            SetA64("0x101110<<1xxxxx011011xxxxxxxxxx", AInstEmit.Umin_V,        typeof(AOpCodeSimdReg));
+            SetA64("0x101110<<1xxxxx101011xxxxxxxxxx", AInstEmit.Uminp_V,       typeof(AOpCodeSimdReg));
             SetA64("0x001110000xxxxx001111xxxxxxxxxx", AInstEmit.Umov_S,        typeof(AOpCodeSimdIns));
             SetA64("0x101110<<1xxxxx110000xxxxxxxxxx", AInstEmit.Umull_V,       typeof(AOpCodeSimdReg));
             SetA64("01111110<<100001010010xxxxxxxxxx", AInstEmit.Uqxtn_S,       typeof(AOpCodeSimd));

--- a/ChocolArm64/Instruction/AInstEmitSimdArithmetic.cs
+++ b/ChocolArm64/Instruction/AInstEmitSimdArithmetic.cs
@@ -71,32 +71,7 @@ namespace ChocolArm64.Instruction
 
         public static void Addp_V(AILEmitterCtx Context)
         {
-            AOpCodeSimdReg Op = (AOpCodeSimdReg)Context.CurrOp;
-
-            int Bytes = Context.CurrOp.GetBitsCount() >> 3;
-
-            int Elems = Bytes >> Op.Size;
-            int Half  = Elems >> 1;
-
-            for (int Index = 0; Index < Elems; Index++)
-            {
-                int Elem = (Index & (Half - 1)) << 1;
-
-                EmitVectorExtractZx(Context, Index < Half ? Op.Rn : Op.Rm, Elem + 0, Op.Size);
-                EmitVectorExtractZx(Context, Index < Half ? Op.Rn : Op.Rm, Elem + 1, Op.Size);
-
-                Context.Emit(OpCodes.Add);
-
-                EmitVectorInsertTmp(Context, Index, Op.Size);
-            }
-
-            Context.EmitLdvectmp();
-            Context.EmitStvec(Op.Rd);
-
-            if (Op.RegisterSize == ARegisterSize.SIMD64)
-            {
-                EmitVectorZeroUpper(Context, Op.Rd);
-            }
+            EmitVectorPairwiseOpZx(Context, () => Context.Emit(OpCodes.Add));
         }
 
         public static void Addv_V(AILEmitterCtx Context)
@@ -1121,6 +1096,15 @@ namespace ChocolArm64.Instruction
             EmitVectorBinaryOpSx(Context, () => Context.EmitCall(MthdInfo));
         }
 
+        public static void Smaxp_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(long), typeof(long) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Max), Types);
+
+            EmitVectorPairwiseOpSx(Context, () => Context.EmitCall(MthdInfo));
+        }
+
         public static void Smin_V(AILEmitterCtx Context)
         {
             Type[] Types = new Type[] { typeof(long), typeof(long) };
@@ -1128,6 +1112,15 @@ namespace ChocolArm64.Instruction
             MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Min), Types);
 
             EmitVectorBinaryOpSx(Context, () => Context.EmitCall(MthdInfo));
+        }
+
+        public static void Sminp_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(long), typeof(long) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Min), Types);
+
+            EmitVectorPairwiseOpSx(Context, () => Context.EmitCall(MthdInfo));
         }
 
         public static void Smlal_V(AILEmitterCtx Context)
@@ -1243,6 +1236,42 @@ namespace ChocolArm64.Instruction
 
                 Context.Emit(OpCodes.Shr_Un);
             });
+        }
+
+        public static void Umin_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(ulong), typeof(ulong) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Min), Types);
+
+            EmitVectorBinaryOpZx(Context, () => Context.EmitCall(MthdInfo));
+        }
+
+        public static void Uminp_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(ulong), typeof(ulong) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Min), Types);
+
+            EmitVectorPairwiseOpZx(Context, () => Context.EmitCall(MthdInfo));
+        }
+
+        public static void Umax_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(ulong), typeof(ulong) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Max), Types);
+
+            EmitVectorBinaryOpZx(Context, () => Context.EmitCall(MthdInfo));
+        }
+
+        public static void Umaxp_V(AILEmitterCtx Context)
+        {
+            Type[] Types = new Type[] { typeof(ulong), typeof(ulong) };
+
+            MethodInfo MthdInfo = typeof(Math).GetMethod(nameof(Math.Max), Types);
+
+            EmitVectorPairwiseOpZx(Context, () => Context.EmitCall(MthdInfo));
         }
 
         public static void Umull_V(AILEmitterCtx Context)

--- a/ChocolArm64/Instruction/AInstEmitSimdHelper.cs
+++ b/ChocolArm64/Instruction/AInstEmitSimdHelper.cs
@@ -132,12 +132,12 @@ namespace ChocolArm64.Instruction
 
             if (SizeF == 0)
             {
-                Type = typeof(Sse);
+                Type     = typeof(Sse);
                 BaseType = typeof(Vector128<float>);
             }
             else /* if (SizeF == 1) */
             {
-                Type = typeof(Sse2);
+                Type     = typeof(Sse2);
                 BaseType = typeof(Vector128<double>);
             }
 
@@ -702,6 +702,46 @@ namespace ChocolArm64.Instruction
 
             Context.EmitLdvectmp();
             Context.EmitStvec(Op.Rd);
+        }
+
+        public static void EmitVectorPairwiseOpSx(AILEmitterCtx Context, Action Emit)
+        {
+            EmitVectorPairwiseOp(Context, Emit, true);
+        }
+
+        public static void EmitVectorPairwiseOpZx(AILEmitterCtx Context, Action Emit)
+        {
+            EmitVectorPairwiseOp(Context, Emit, false);
+        }
+
+        private static void EmitVectorPairwiseOp(AILEmitterCtx Context, Action Emit, bool Signed)
+        {
+            AOpCodeSimdReg Op = (AOpCodeSimdReg)Context.CurrOp;
+
+            int Bytes = Context.CurrOp.GetBitsCount() >> 3;
+
+            int Elems = Bytes >> Op.Size;
+            int Half  = Elems >> 1;
+
+            for (int Index = 0; Index < Elems; Index++)
+            {
+                int Elem = (Index & (Half - 1)) << 1;
+
+                EmitVectorExtract(Context, Index < Half ? Op.Rn : Op.Rm, Elem + 0, Op.Size, Signed);
+                EmitVectorExtract(Context, Index < Half ? Op.Rn : Op.Rm, Elem + 1, Op.Size, Signed);
+
+                Emit();
+
+                EmitVectorInsertTmp(Context, Index, Op.Size);
+            }
+
+            Context.EmitLdvectmp();
+            Context.EmitStvec(Op.Rd);
+
+            if (Op.RegisterSize == ARegisterSize.SIMD64)
+            {
+                EmitVectorZeroUpper(Context, Op.Rd);
+            }
         }
 
         public static void EmitScalarSet(AILEmitterCtx Context, int Reg, int Size)

--- a/ChocolArm64/Translation/ILGeneratorEx.cs
+++ b/ChocolArm64/Translation/ILGeneratorEx.cs
@@ -63,7 +63,7 @@ namespace ChocolArm64
             else
             {
                 throw new ArgumentOutOfRangeException(nameof(Index));
-            } 
+            }
         }
 
         public static void EmitLdloc(this ILGenerator Generator, int Index)
@@ -89,7 +89,7 @@ namespace ChocolArm64
                         throw new ArgumentOutOfRangeException(nameof(Index));
                     }
                     break;
-            }            
+            }
         }
 
         public static void EmitStloc(this ILGenerator Generator, int Index)
@@ -123,7 +123,7 @@ namespace ChocolArm64
             for (int Index = 0; Index < Count; Index++)
             {
                 Generator.EmitLdarg(Index);
-            }         
+            }
         }
     }
 }


### PR DESCRIPTION
Also added an EmitVectorPairwiseOp method used by the *P variants and modified ADDP to use it.
Not tested yet.