### PR TITLE
Remove broken adds/cmn with condition check optimization

### DIFF
--- a/ChocolArm64/Instruction/AInstEmitAlu.cs
+++ b/ChocolArm64/Instruction/AInstEmitAlu.cs
@@ -50,8 +50,6 @@ namespace ChocolArm64.Instruction
 
         public static void Adds(AILEmitterCtx Context)
         {
-            Context.TryOptMarkCondWithoutCmp();
-
             EmitDataLoadOpers(Context);
 
             Context.Emit(OpCodes.Add);

--- a/ChocolArm64/Translation/AILEmitterCtx.cs
+++ b/ChocolArm64/Translation/AILEmitterCtx.cs
@@ -187,11 +187,6 @@ namespace ChocolArm64.Translation
                 Ldloc(Tmp3Index, AIoType.Int, OptOpLastCompare.RegisterSize);
                 Ldloc(Tmp4Index, AIoType.Int, OptOpLastCompare.RegisterSize);
 
-                if (OptOpLastCompare.Emitter == AInstEmit.Adds)
-                {
-                    Emit(OpCodes.Neg);
-                }
-
                 ILOp = BranchOps[Cond];
             }
             else if (IntCond < 14)


### PR DESCRIPTION
It was emiting bogus condition checks when the adds instruction was used with a conditional instruction on the same basic block. Reported by roblabla.

FYI @LDj3SNuD, it may be worth to expand the tests to catch cases like this later, by writing some small programs with simple instruction sequences.

Example repro program:
```
mov x8, #0
mov x9, #0
adds x8, x8, x9
cset w10, CS
tbnz w10, #0, panic
mov x0, #2
ret
panic:
mov x0, #1
ret
```
X0 should contain 2 but it contains 1 when the test finishes.