### PR TITLE
Implement GPU primitive restart

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -36,6 +36,12 @@ namespace Ryujinx.Graphics.Gal
 
         void SetClearStencil(int Stencil);
 
+        void EnablePrimitiveRestart();
+
+        void DisablePrimitiveRestart();
+
+        void SetPrimitiveRestartIndex(uint Index);
+
         void CreateVbo(long Key, byte[] Buffer);
 
         void CreateIbo(long Key, byte[] Buffer);

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -184,6 +184,21 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             GL.ClearStencil(Stencil);
         }
 
+        public void EnablePrimitiveRestart()
+        {
+            GL.Enable(EnableCap.PrimitiveRestart);
+        }
+
+        public void DisablePrimitiveRestart()
+        {
+            GL.Disable(EnableCap.PrimitiveRestart);
+        }
+
+        public void SetPrimitiveRestartIndex(uint Index)
+        {
+            GL.PrimitiveRestartIndex(Index);
+        }
+
         public void CreateVbo(long Key, byte[] Buffer)
         {
             int Handle = GL.GenBuffer();

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -85,6 +85,7 @@ namespace Ryujinx.HLE.Gpu.Engines
             SetDepth();
             SetStencil();
             SetAlphaBlending();
+            SetPrimitiveRestart();
 
             UploadTextures(Vmm, Keys);
             UploadUniforms(Vmm);
@@ -387,6 +388,29 @@ namespace Ryujinx.HLE.Gpu.Engines
             {
                 Gpu.Renderer.Blend.Set(EquationRgb, FuncSrcRgb, FuncDstRgb);
             }
+        }
+
+        private void SetPrimitiveRestart()
+        {
+            bool Enable = (ReadRegister(NvGpuEngine3dReg.PrimRestartEnable) & 1) != 0;
+
+            if (Enable)
+            {
+                Gpu.Renderer.Rasterizer.EnablePrimitiveRestart();
+            }
+            else
+            {
+                Gpu.Renderer.Rasterizer.DisablePrimitiveRestart();
+            }
+
+            if (!Enable)
+            {
+                return;
+            }
+
+            uint Index = (uint)ReadRegister(NvGpuEngine3dReg.PrimRestartIndex);
+
+            Gpu.Renderer.Rasterizer.SetPrimitiveRestartIndex(Index);
         }
 
         private void UploadTextures(NvGpuVmm Vmm, long[] Keys)

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3dReg.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3dReg.cs
@@ -50,6 +50,8 @@ namespace Ryujinx.HLE.Gpu.Engines
         StencilBackFuncFunc  = 0x569,
         ShaderAddress        = 0x582,
         VertexBeginGl        = 0x586,
+        PrimRestartEnable    = 0x591,
+        PrimRestartIndex     = 0x592,
         IndexArrayAddress    = 0x5f2,
         IndexArrayEndAddr    = 0x5f4,
         IndexArrayFormat     = 0x5f6,


### PR DESCRIPTION
Implement the most common way to primtive restart indexed vertices.
Reg 0x0de8 (PRIM_RESTART_WITH_DRAW_ARRAYS) is still unimplemented.