### PR TITLE
Disable front facing and face culling to avoid regression

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLFrameBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLFrameBuffer.cs
@@ -239,7 +239,19 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             {
                 EnsureInitialized();
 
-                bool AlphaBlendEnable = GL.GetInteger(GetPName.Blend) != 0;
+                //bool CullFaceEnable = GL.IsEnabled(EnableCap.CullFace);
+
+                bool DepthTestEnable = GL.IsEnabled(EnableCap.DepthTest);
+
+                bool StencilTestEnable = GL.IsEnabled(EnableCap.StencilTest);
+
+                bool AlphaBlendEnable = GL.IsEnabled(EnableCap.Blend);
+
+                //GL.Disable(EnableCap.CullFace);
+
+                GL.Disable(EnableCap.DepthTest);
+
+                GL.Disable(EnableCap.StencilTest);
 
                 GL.Disable(EnableCap.Blend);
 
@@ -267,6 +279,21 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, CurrFbHandle);
 
                 GL.UseProgram(CurrentProgram);
+
+                //if (CullFaceEnable)
+                //{
+                //    GL.Enable(EnableCap.CullFace);
+                //}
+
+                if (DepthTestEnable)
+                {
+                    GL.Enable(EnableCap.DepthTest);
+                }
+
+                if (StencilTestEnable)
+                {
+                    GL.Enable(EnableCap.StencilTest);
+                }
 
                 if (AlphaBlendEnable)
                 {

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -79,8 +79,9 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             Gpu.Renderer.Shader.BindProgram();
 
-            SetFrontFace();
-            SetCullFace();
+            //Note: Uncomment SetFrontFace SetCullFace when flipping issues are solved
+            //SetFrontFace();
+            //SetCullFace();
             SetDepth();
             SetStencil();
             SetAlphaBlending();


### PR DESCRIPTION
There is a regression when face culling is enabled. It may be linked to flipping issues.
Since face culling is something that's very unlikely to cause problems when disabled, this is a solution until flipping issues are solved.

Added a commented section in OGLFramebuffer to disable face culling.