### PR TITLE
Add locking methods to the ogl resource cache

### DIFF
--- a/Ryujinx.Graphics/Gal/GalTextureFormat.cs
+++ b/Ryujinx.Graphics/Gal/GalTextureFormat.cs
@@ -17,6 +17,7 @@ namespace Ryujinx.Graphics.Gal
         BC3          = 0x26,
         BC4          = 0x27,
         BC5          = 0x28,
+        ZF32         = 0x2f,
         Astc2D4x4    = 0x40,
         Astc2D5x5    = 0x41,
         Astc2D6x6    = 0x42,

--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -2,6 +2,9 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalRasterizer
     {
+        void LockCaches();
+        void UnlockCaches();
+
         void ClearBuffers(GalClearBufferFlags Flags);
 
         bool IsVboCached(long Key, long DataSize);

--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -49,9 +49,9 @@ namespace Ryujinx.Graphics.Gal
 
         void CreateIbo(long Key, byte[] Buffer);
 
-        void SetVertexArray(int VbIndex, int Stride, long VboKey, GalVertexAttrib[] Attribs);
+        void SetVertexArray(int Stride, long VboKey, GalVertexAttrib[] Attribs);
 
-        void SetIndexArray(long Key, int Size, GalIndexFormat Format);
+        void SetIndexArray(int Size, GalIndexFormat Format);
 
         void DrawArrays(int First, int PrimCount, GalPrimitiveType PrimType);
 

--- a/Ryujinx.Graphics/Gal/IGalTexture.cs
+++ b/Ryujinx.Graphics/Gal/IGalTexture.cs
@@ -2,6 +2,9 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalTexture
     {
+        void LockCache();
+        void UnlockCache();
+
         void Create(long Key, byte[] Data, GalTexture Texture);
 
         bool TryGetCachedTexture(long Key, long DataSize, out GalTexture Texture);

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
@@ -129,15 +129,16 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             switch (Format)
             {
-                case GalTextureFormat.R32G32B32A32: return (PixelFormat.Rgba, PixelType.Float);
-                case GalTextureFormat.R16G16B16A16: return (PixelFormat.Rgba, PixelType.HalfFloat);
-                case GalTextureFormat.A8B8G8R8:     return (PixelFormat.Rgba, PixelType.UnsignedByte);
-                case GalTextureFormat.R32:          return (PixelFormat.Red,  PixelType.Float);
-                case GalTextureFormat.A1B5G5R5:     return (PixelFormat.Rgba, PixelType.UnsignedShort5551);
-                case GalTextureFormat.B5G6R5:       return (PixelFormat.Rgb,  PixelType.UnsignedShort565);
-                case GalTextureFormat.G8R8:         return (PixelFormat.Rg,   PixelType.UnsignedByte);
-                case GalTextureFormat.R16:          return (PixelFormat.Red,  PixelType.HalfFloat);
-                case GalTextureFormat.R8:           return (PixelFormat.Red,  PixelType.UnsignedByte);
+                case GalTextureFormat.R32G32B32A32: return (PixelFormat.Rgba,           PixelType.Float);
+                case GalTextureFormat.R16G16B16A16: return (PixelFormat.Rgba,           PixelType.HalfFloat);
+                case GalTextureFormat.A8B8G8R8:     return (PixelFormat.Rgba,           PixelType.UnsignedByte);
+                case GalTextureFormat.R32:          return (PixelFormat.Red,            PixelType.Float);
+                case GalTextureFormat.A1B5G5R5:     return (PixelFormat.Rgba,           PixelType.UnsignedShort5551);
+                case GalTextureFormat.B5G6R5:       return (PixelFormat.Rgb,            PixelType.UnsignedShort565);
+                case GalTextureFormat.G8R8:         return (PixelFormat.Rg,             PixelType.UnsignedByte);
+                case GalTextureFormat.R16:          return (PixelFormat.Red,            PixelType.HalfFloat);
+                case GalTextureFormat.R8:           return (PixelFormat.Red,            PixelType.UnsignedByte);
+                case GalTextureFormat.ZF32:         return (PixelFormat.DepthComponent, PixelType.Float);
             }
 
             throw new NotImplementedException(Format.ToString());

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -235,7 +235,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             GL.BufferData(BufferTarget.ElementArrayBuffer, Length, Buffer, BufferUsageHint.StreamDraw);
         }
 
-        public void SetVertexArray(int VbIndex, int Stride, long VboKey, GalVertexAttrib[] Attribs)
+        public void SetVertexArray(int Stride, long VboKey, GalVertexAttrib[] Attribs)
         {
             if (!VboCache.TryGetValue(VboKey, out int VboHandle))
             {
@@ -282,7 +282,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
         }
 
-        public void SetIndexArray(long Key, int Size, GalIndexFormat Format)
+        public void SetIndexArray(int Size, GalIndexFormat Format)
         {
             IndexBuffer.Type = OGLEnumConverter.GetDrawElementsType(Format);
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -71,6 +71,18 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             IndexBuffer = new IbInfo();
         }
 
+        public void LockCaches()
+        {
+            VboCache.Lock();
+            IboCache.Lock();
+        }
+
+        public void UnlockCaches()
+        {
+            VboCache.Unlock();
+            IboCache.Unlock();
+        }
+
         public void ClearBuffers(GalClearBufferFlags Flags)
         {
             ClearBufferMask Mask = ClearBufferMask.ColorBufferBit;

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
@@ -26,6 +26,16 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             TextureCache = new OGLCachedResource<TCE>(DeleteTexture);
         }
 
+        public void LockCache()
+        {
+            TextureCache.Lock();
+        }
+
+        public void UnlockCache()
+        {
+            TextureCache.Unlock();
+        }
+
         private static void DeleteTexture(TCE CachedTexture)
         {
             GL.DeleteTexture(CachedTexture.Handle);

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -586,7 +586,7 @@ namespace Ryujinx.HLE.Gpu.Engines
                     Gpu.Renderer.Rasterizer.CreateIbo(IboKey, Data);
                 }
 
-                Gpu.Renderer.Rasterizer.SetIndexArray(IboKey, IbSize, IndexFormat);
+                Gpu.Renderer.Rasterizer.SetIndexArray(IbSize, IndexFormat);
             }
 
             List<GalVertexAttrib>[] Attribs = new List<GalVertexAttrib>[32];
@@ -650,7 +650,7 @@ namespace Ryujinx.HLE.Gpu.Engines
                     Gpu.Renderer.Rasterizer.CreateVbo(VboKey, Data);
                 }
 
-                Gpu.Renderer.Rasterizer.SetVertexArray(Index, Stride, VboKey, Attribs[Index].ToArray());
+                Gpu.Renderer.Rasterizer.SetVertexArray(Stride, VboKey, Attribs[Index].ToArray());
             }
 
             GalPrimitiveType PrimType = (GalPrimitiveType)(PrimCtrl & 0xffff);

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -73,6 +73,8 @@ namespace Ryujinx.HLE.Gpu.Engines
 
         private void VertexEndGl(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
         {
+            LockCaches();
+
             SetFrameBuffer(Vmm, 0);
 
             long[] Keys = UploadShaders(Vmm);
@@ -90,6 +92,20 @@ namespace Ryujinx.HLE.Gpu.Engines
             UploadTextures(Vmm, Keys);
             UploadUniforms(Vmm);
             UploadVertexArrays(Vmm);
+
+            UnlockCaches();
+        }
+
+        private void LockCaches()
+        {
+            Gpu.Renderer.Rasterizer.LockCaches();
+            Gpu.Renderer.Texture.LockCache();
+        }
+
+        private void UnlockCaches()
+        {
+            Gpu.Renderer.Rasterizer.UnlockCaches();
+            Gpu.Renderer.Texture.UnlockCache();
         }
 
         private void ClearBuffers(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)

--- a/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
@@ -28,15 +28,25 @@ namespace Ryujinx.HLE.Gpu.Texture
         {
             switch (Texture.Format)
             {
-                case GalTextureFormat.R32G32B32A32: return Texture.Width * Texture.Height * 16;
-                case GalTextureFormat.R16G16B16A16: return Texture.Width * Texture.Height * 8;
-                case GalTextureFormat.A8B8G8R8:     return Texture.Width * Texture.Height * 4;
-                case GalTextureFormat.R32:          return Texture.Width * Texture.Height * 4;
-                case GalTextureFormat.A1B5G5R5:     return Texture.Width * Texture.Height * 2;
-                case GalTextureFormat.B5G6R5:       return Texture.Width * Texture.Height * 2;
-                case GalTextureFormat.G8R8:         return Texture.Width * Texture.Height * 2;
-                case GalTextureFormat.R16:          return Texture.Width * Texture.Height * 2;
-                case GalTextureFormat.R8:           return Texture.Width * Texture.Height;
+                case GalTextureFormat.R32G32B32A32:
+                    return Texture.Width * Texture.Height * 16;
+
+                case GalTextureFormat.R16G16B16A16:
+                    return Texture.Width * Texture.Height * 8;
+
+                case GalTextureFormat.A8B8G8R8:
+                case GalTextureFormat.R32:
+                case GalTextureFormat.ZF32:
+                    return Texture.Width * Texture.Height * 4;
+
+                case GalTextureFormat.A1B5G5R5:
+                case GalTextureFormat.B5G6R5:
+                case GalTextureFormat.G8R8:
+                case GalTextureFormat.R16:
+                    return Texture.Width * Texture.Height * 2;
+
+                case GalTextureFormat.R8:
+                    return Texture.Width * Texture.Height;
 
                 case GalTextureFormat.BC1:
                 case GalTextureFormat.BC4:

--- a/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
@@ -25,6 +25,7 @@ namespace Ryujinx.HLE.Gpu.Texture
                 case GalTextureFormat.BC3:          return Read16Bpt4x4(Memory, Texture);
                 case GalTextureFormat.BC4:          return Read8Bpt4x4 (Memory, Texture);
                 case GalTextureFormat.BC5:          return Read16Bpt4x4(Memory, Texture);
+                case GalTextureFormat.ZF32:         return Read4Bpp    (Memory, Texture);
                 case GalTextureFormat.Astc2D4x4:    return Read16Bpt4x4(Memory, Texture);
             }
 


### PR DESCRIPTION
Currently the following scenario is possible:

- Vertex Buffer with Key 0xaaaa is used, handle 1 is generated and added to the dictionary.
- Handle 1 is bound to a VAO.
- Vertex Buffer with Key 0xaaaa (same vertex buffer, but this time used in a different VB entry slot) is used, handle 2 is generated. Since the key already exists on the dictionary, it deletes the old entry (deleting handle 1!) and updates the entry on the dictionary.

When Draw* is done to actually render that, one of the handles was deleted and the data no longer exists. Oops!

This situation is fixed by adding a locking mechanism. When `Lock` is called it won't delete anything. Instead, buffers that needs to be deleted are queued to be deleted later. When `Unlock` is called, all queued buffers are deleted, and also possible old/unused buffers. This also fixes a small issue where the timestamp of frequently used data wouldn't be updated (thus allowing frequently used data to be deleted).