### PR TITLE
Allow sample rate of 0 on OpenAudioOut, fix 5.1 sound output

### DIFF
--- a/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
+++ b/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Audio.OpenAL
             public int SourceId { get; private set; }
 
             public int SampleRate { get; private set; }
-            
+
             public ALFormat Format { get; private set; }
 
             private ReleaseCallback Callback;
@@ -153,7 +153,7 @@ namespace Ryujinx.Audio.OpenAL
                     ShouldCallReleaseCallback = true;
                 }
             }
-            
+
             private void SyncQueuedTags()
             {
                 AL.GetSource(SourceId, ALGetSourcei.BuffersQueued,    out int QueuedCount);
@@ -249,11 +249,6 @@ namespace Ryujinx.Audio.OpenAL
 
         private ALFormat GetALFormat(int Channels, AudioFormat Format)
         {
-            if (Channels < 1 || Channels > 2)
-            {
-                throw new ArgumentOutOfRangeException(nameof(Channels));
-            }
-
             if (Channels == 1)
             {
                 switch (Format)
@@ -262,13 +257,25 @@ namespace Ryujinx.Audio.OpenAL
                     case AudioFormat.PcmInt16: return ALFormat.Mono16;
                 }
             }
-            else /* if (Channels == 2) */
+            else if (Channels == 2)
             {
                 switch (Format)
                 {
                     case AudioFormat.PcmInt8:  return ALFormat.Stereo8;
                     case AudioFormat.PcmInt16: return ALFormat.Stereo16;
                 }
+            }
+            else if (Channels == 6)
+            {
+                switch (Format)
+                {
+                    case AudioFormat.PcmInt8:  return ALFormat.Multi51Chn8Ext;
+                    case AudioFormat.PcmInt16: return ALFormat.Multi51Chn16Ext;
+                }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(Channels));
             }
 
             throw new ArgumentException(nameof(Format));
@@ -288,7 +295,7 @@ namespace Ryujinx.Audio.OpenAL
             {
                 return Td.ContainsBuffer(Tag);
             }
-            
+
             return false;
         }
 
@@ -298,7 +305,7 @@ namespace Ryujinx.Audio.OpenAL
             {
                 return Td.GetReleasedBuffers(MaxCount);
             }
-            
+
             return null;
         }
 

--- a/Ryujinx.HLE/OsHle/Services/Aud/IAudioOutManager.cs
+++ b/Ryujinx.HLE/OsHle/Services/Aud/IAudioOutManager.cs
@@ -14,6 +14,10 @@ namespace Ryujinx.HLE.OsHle.Services.Aud
     {
         private const string DefaultAudioOutput = "DeviceOut";
 
+        private const int DefaultSampleRate = 48000;
+
+        private const int DefaultChannelsCount = 2;
+
         private Dictionary<int, ServiceProcessRequest> m_Commands;
 
         public override IReadOnlyDictionary<int, ServiceProcessRequest> Commands => m_Commands;
@@ -122,7 +126,12 @@ namespace Ryujinx.HLE.OsHle.Services.Aud
             int SampleRate = Context.RequestData.ReadInt32();
             int Channels   = Context.RequestData.ReadInt32();
 
-            if (SampleRate != 48000)
+            if (SampleRate == 0)
+            {
+                SampleRate = DefaultSampleRate;
+            }
+
+            if (SampleRate != DefaultSampleRate)
             {
                 Context.Ns.Log.PrintWarning(LogClass.Audio, "Invalid sample rate!");
 
@@ -133,7 +142,7 @@ namespace Ryujinx.HLE.OsHle.Services.Aud
 
             if (Channels == 0)
             {
-                Channels = 2;
+                Channels = DefaultChannelsCount;
             }
 
             KEvent ReleaseEvent = new KEvent();
@@ -145,7 +154,7 @@ namespace Ryujinx.HLE.OsHle.Services.Aud
 
             IAalOutput AudioOut = Context.Ns.AudioOut;
 
-            int Track = AudioOut.OpenTrack(SampleRate, 2, Callback, out AudioFormat Format);
+            int Track = AudioOut.OpenTrack(SampleRate, Channels, Callback, out AudioFormat Format);
 
             MakeObject(Context, new IAudioOut(AudioOut, ReleaseEvent, Track));
 


### PR DESCRIPTION
This fixes mono and 5.1 sound output. Additionally, it also fixes a regression when the sample rate is 0.